### PR TITLE
VM records execution coverage for the constructs it lowers inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The bytecode VM produced no execution-coverage evidence for any construct
+  it lowers inline**, so the cross-engine differential gate could never credit
+  `+`, `-`, `*`, `display`, `if`, `let`, `cond`, `do`, `lambda` or any other
+  fast-path form no matter how many programs exercised them. Under
+  `ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR`, `(display (+ 1 2))` made native write
+  six records and the VM write no trace file at all: the VM's only two markers
+  fired from builtin dispatch (`vm_language_coverage_native_dispatch` and
+  `_named_call`), which a lowered opcode never reaches.
+
+  The VM compiler now emits `OP_LANGUAGE_COVERAGE_FORM` at the head of every
+  compiled `(name ...)` form when tracing is armed, carrying the same stable
+  31-bit head-symbol hash the call marker uses, and reaching it at run time is
+  the construct's execution evidence. The marker survives ESKB serialization,
+  so the standalone VM binary and the `--profile hosted-vm` route report
+  identically. `scripts/run_engine_parity_coverage.py` resolves the VM's hash
+  markers against the surface manifest with collision rejection instead of
+  reading the literal marker word, and `scripts/language_coverage.py` accepts
+  `@form` beside `@call`.
+
+  Differential construct coverage rose from 194/1137 (17.06%) to 303/1137
+  (26.65%), and high-risk differential coverage from 102/473 (21.56%) to
+  152/473 (32.14%), against a native-side corpus ceiling of 171/473 (36.15%).
+  Instrumentation stays opt-in and behaviour-neutral: an unarmed run emits no
+  extra instruction, and all 262 corpus programs produce byte-identical VM
+  output armed and unarmed.
+
 ## [1.3.5-evolve] - 2026-09-07
 
 Release verification is pending; see `RELEASE_NOTES.md` for the final-battery

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -903,7 +903,7 @@ not-yet-production, and is listed above accordingly.)
 | Feature | Status | Notes |
 |---------|--------|-------|
 | **Bytecode VM** |
-| 66-opcode core ISA | Yes | Register+stack architecture, computed-goto dispatch; `OP_COUNT = 66` in `lib/backend/vm_core.c`, the enum `vm_run.c`'s dispatch table indexes — corrected 2026-08-25 from "64" (conformity audit item d7; three other `OpCode` definitions elsewhere in `lib/backend/` disagree at 63, a separate ODR-cleanup code issue tracked independently of this doc) |
+| 72-opcode core ISA | Yes | Register+stack architecture, computed-goto dispatch; `OP_COUNT = 72` in `lib/backend/vm_core.c`, the enum `vm_run.c`'s dispatch table indexes — corrected 2026-08-25 from "64" (conformity audit item d7) and remeasured here after the long-closure, secondary-raise, popped-tail-call and per-form-coverage opcodes (67-71) landed. `lib/backend/eshkol_compiler.c` mirrors the enum exactly; `lib/backend/eshkol_benchmark.c` still declares its own `OpCode` stopping at 63, a separate ODR-cleanup code issue tracked independently of this doc |
 | 722 VM-reachable native call IDs | Yes | Math, string, IO, complex, rational, bignum, dual, AD, tensor, logic, inference, workspace, hash, bytevector, parameter; `tests/coverage/language_surface.json` `counts.builtins_in_vm_table` — corrected 2026-08-25 from "694" (conformity audit item d7) |
 | ESKB binary format | Yes | Section-based layout, LEB128 encoding, CRC32 checksums |
 | `-B` flag (bytecode emission) | Yes | `eshkol-run input.esk -B output.eskb` |

--- a/docs/VM_PARITY.md
+++ b/docs/VM_PARITY.md
@@ -41,6 +41,25 @@ to miss.
   floor in `ENGINE_PARITY_BASELINE.json` hold, with no new divergence and no
   regression of a program previously observed on both engines. A passing
   name-resolution or one-engine coverage run cannot satisfy this criterion.
+- **Per-form VM evidence (D-03 (i)).** The VM used to record coverage only
+  from builtin dispatch, so every construct it lowers inline — the arithmetic
+  and comparison opcodes, and `if`/`let`/`cond`/`do`/`lambda` — earned no
+  differential credit at all and `(display (+ 1 2))` produced no VM trace
+  file. The VM compiler now emits `OP_LANGUAGE_COVERAGE_FORM` at the head of
+  every compiled `(name ...)` form when
+  `ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR` is set, carrying the same stable
+  31-bit head-symbol hash the call marker uses, and the marker survives ESKB
+  serialization so the standalone VM binary and the `--profile hosted-vm`
+  route report identically. Differential coverage measured 303/1137 (26.65%)
+  and high-risk 152/473 (32.14%) on `integration/astra-v135`.
+- **The high-risk floor is not yet attainable.** Running native alone over the
+  gate's default corpus, the parser records 171 of 473 high-risk constructs
+  (36.15%), and a construct no corpus program mentions can never earn
+  differential credit on either engine. The recorded
+  `high_risk_differential_floor` of `1.0` is therefore above the corpus
+  ceiling; it is a target to build up to with corpus growth, not a
+  measurement, and `--update-baseline` writes it as a literal rather than
+  observing it.
 
 ### v1.3.5-evolve surface closure
 

--- a/docs/design/FLAW_DETECTION_ROADMAP.md
+++ b/docs/design/FLAW_DETECTION_ROADMAP.md
@@ -87,7 +87,7 @@ All three factors matter and the project is currently weak on all three:
 | Factor | Current state | Evidence |
 |---|---|---|
 | Defect classes detectable | The correctness chain detects value and lexical disagreement only; behavioral probes do not exist | ICC correctness chain caught 0 of 62 ledgered defects |
-| Surface fraction per detector | Execution coverage 100.00%; **comparison** coverage 12.21% | `run_language_coverage.sh` vs `run_engine_parity_coverage.py` |
+| Surface fraction per detector | Execution coverage 100.00%; **comparison** coverage 12.21% when this was written, 26.65% once the VM emitted per-form markers (D-03 (i)) | `run_language_coverage.sh` vs `run_engine_parity_coverage.py` |
 | Frequency the detector runs | 14 of ~90 harnesses are reachable from any CI workflow | `.github/workflows/` grep, section D-13 |
 
 ### The doctrine this implies
@@ -244,13 +244,33 @@ barely.
 Ledger entry PR-10 records the consequence: SW-01, SW-02, SW-06 and SW-08 all live in the
 87.79% with no differential evidence at all.
 
-**Why the number is stuck where it is — and it is not corpus.** The VM emits per-construct
-coverage markers only from `vm_language_coverage_native_dispatch` and `_named_call`, i.e.
-from **builtin dispatch**. Special forms (`if`, `quote`, `let`, `cond`, `do`, `lambda`) are
-compiled inline in `lib/backend/vm_compiler.c` and emit **no marker at all**, so they can
-never earn differential credit no matter how many programs exercise them. Adding VM coverage
-markers to special forms is a prerequisite for the number to move, and is the highest-value
-follow-up named in the task #109 handoff.
+**Why the number was stuck where it was — and it was not corpus.** The VM emitted
+per-construct coverage markers only from `vm_language_coverage_native_dispatch` and
+`_named_call`, i.e. from **builtin dispatch**. Special forms (`if`, `quote`, `let`, `cond`,
+`do`, `lambda`) and the arithmetic/comparison opcode fast paths are compiled inline in
+`lib/backend/vm_compiler.c` and emitted **no marker at all**, so they could never earn
+differential credit no matter how many programs exercise them. `(display (+ 1 2))` made
+native write six coverage records and made the VM write no trace file whatsoever.
+
+**Status: prerequisite (i) has landed.** The VM compiler now emits
+`OP_LANGUAGE_COVERAGE_FORM` at the head of every compiled `(name ...)` form when tracing is
+armed; reaching it at run time is that construct's execution evidence, and the differential
+gate resolves the marker's stable head-symbol hash against the surface manifest with
+collision rejection. On `integration/astra-v135` that moved differential construct coverage
+from **194/1137 (17.06%) to 303/1137 (26.65%)** and high-risk differential coverage from
+**102/473 (21.56%) to 152/473 (32.14%)**.
+
+**What still caps the number, and it now IS corpus.** Running only native over the gate's
+default corpus, the parser records **171 of the 473 high-risk constructs (36.15%)** — a
+construct no corpus program mentions cannot earn differential credit on either engine. So
+36.15% is the arithmetic ceiling for high-risk differential coverage on today's corpus, and
+the `high_risk_differential_floor: 1.0` recorded in
+`tests/vm_parity/ENGINE_PARITY_BASELINE.json` is unreachable without corpus growth. That
+floor was never measured: `--update-baseline` writes the literal `1.0` rather than the
+observed fraction, so the sub-gate has never been green since it was added. Prerequisites
+(ii) and (iii) — the published rising schedule and the first-class
+`constructs_without_differential_evidence` number — are what convert that from an
+unattainable constant into a burn-down.
 
 **Second structural note.** Both parity probes grade **non-growth**, not correctness:
 `engine_semantic_parity` passes at `10 divergent program(s), 0 new`, and
@@ -650,7 +670,7 @@ first version: S = 1-2d, M = 3-5d, L = 6-12d, XL = a campaign.
 | D-01 | **Value-position axis.** One generated program per builtin evaluating the same call twice — call position and through a higher-order procedure — compared with `equal?` inside the program. Differential by construction: no hard-coded expectation, so it cannot pass by agreeing with a wrong answer. Extend to the VM axis, to `.esk` stdlib exports, and to `stored`/`returned`/`mapped` probes | repo gate + corpus generator | S (land) + M (extend) | `scripts/run_value_position_sweep.py` and `tests/value_position/BASELINE.json`, both on `fix/value-position-axis` |
 | D-02 | **Property-oracle family expansion.** Add families to P8 axis 4 and to the P7c `meta` generator for the classes this campaign proved dangerous: `scope` (a binding must shadow a same-named global on every route: call, HOF, AD operand, `set!` target), `order` (min/max/sort must agree with the engine's own `<` on the same operands, in both operand orders), `exact` (the defining inequalities of `floor`/`ceiling`/`truncate`/`round`, checked not tabulated), `hygiene` (the 18-cell matrix as generated properties), `adcompose` (nested-differentiation identities). Separately: **add a VM axis to the reference differential**, and **audit every normalizer** for the property it erases | corpus generator + repo gate | M per family; M for the VM axis | `scripts/p8/gen_property_oracles.py` (3 families); `scripts/gen_generative_corpus.py` `meta` family (7 properties); PR #439's tests 63/64/65 are three of these hand-written; `scripts/run_reference_differential.sh` |
 | D-02 | **Equivalence modulo inputs (EMI).** Take a program that runs green, mutate code that the observed execution never reaches (Orion) or that runs but cannot affect the printed result (Hermes), and require byte-identical output. This is the canonical answer to shared-defect blindness in the compiler-testing literature and it needs **no reference implementation and no expected value** — the original program is its own oracle. The generator this needs already exists | corpus generator | M | `scripts/gen_generative_corpus.py` (program generator) plus the per-construct coverage trace (which lines executed) already emitted by both engines |
-| D-03 | **Comparison-coverage climb.** (i) Emit VM language-coverage markers from the special-form compile paths in `vm_compiler.c` — without this the fraction is capped. (ii) Convert the floor from "do not regress" to a **published rising schedule** with a date per step. (iii) Report `constructs_without_differential_evidence` as a first-class number in the readiness output | repo gate + oracle criterion | L | `scripts/run_engine_parity_coverage.py` (floor mechanism already built); task #109 |
+| D-03 | **Comparison-coverage climb.** (i) **LANDED** — VM language-coverage markers are emitted for every compiled form (`OP_LANGUAGE_COVERAGE_FORM`), lifting differential coverage 17.06% -> 26.65% and high-risk 21.56% -> 32.14%; what caps it now is the corpus, whose native side mentions only 171 of 473 high-risk constructs. (ii) Convert the floor from "do not regress" to a **published rising schedule** with a date per step. (iii) Report `constructs_without_differential_evidence` as a first-class number in the readiness output | repo gate + oracle criterion | L | `scripts/run_engine_parity_coverage.py` (floor mechanism already built); task #109 |
 | D-04 | **Pairwise crossing coverage.** Instrument the existing per-construct coverage records to emit *co-occurrence* pairs per program, then report 2-wise interaction coverage over a declared high-risk construct set (AD operators x binding forms x higher-order builtins x numeric tower x macro forms). A generator fills the empty cells. The measurement alone is valuable before any generator exists: it turns "we have AD tests and shadowing tests" into a number | repo gate, then corpus generator | M (measure) + L (generate) | the coverage trace format already emitted by both engines (`P`/`V` records); `scripts/gen_generative_corpus.py` is the generator to extend, not to replace |
 | D-05 | **Self-verdict scanner, everywhere.** Extract the FAIL-line scan that 20 suites already carry into one shared helper, and apply it on **every** lane including VM, wasm and AOT. Any test whose stdout contains a self-reported failure is a gate failure regardless of exit status or cross-engine agreement. Plus: **re-run `tests/vm_parity/found/` inside the parity gate** and fail on a reproducer that no longer reproduces (it is either fixed — close the ledger entry — or the reproducer rotted) | repo gate | S | `scripts/run_parser_tests.sh` lines 83-88; DD-12 |
 | D-06 | **Threshold-bearing invariants.** Add an invariant kind that grades a *payload field* against a bound, and convert `INV-engine-semantic-parity` and `INV-language-surface-exercise` to it. Then add a meta-check: any invariant whose `severity` is `critical` and whose `kind` is `exercise` is itself a finding | ICC detector + `.icc/architecture-model.yaml` | M | `kind: perturbation` and `kind: key-space-equality` already exist in the model; ICC `vacuous-assertions` is the adjacent detector |
@@ -871,6 +891,7 @@ not a target.
 | Ledgered defects found by the ICC correctness chain | 0 of 62 | the `missed_by:` field of `.icc/silent-wrong-ledger.yaml`, which names `icc-correctness-chain` on 43 entries |
 | Language-surface execution coverage | 1091 / 1091 = 100.00% | `run_language_coverage.sh` |
 | Engine differential construct coverage | 136 / 1114 = 12.21% (floor 10.95%) | `run_engine_parity_coverage.py`, PR #424 |
+| Engine differential construct coverage, after D-03 (i) | 303 / 1137 = 26.65% (floor 13.35%); high-risk 152 / 473 = 32.14% against a 36.15% corpus ceiling | `run_engine_parity_coverage.py` on `integration/astra-v135` |
 | Correctness harnesses reachable from CI | 14 of ~90 | `.github/workflows/` |
 | Layout `static_assert`s in `lib/` + `inc/` | 0 | grep |
 | Freshness guards in the 4 release-critical harnesses | 0 | grep |

--- a/inc/eshkol/core/runtime.h
+++ b/inc/eshkol/core/runtime.h
@@ -564,6 +564,20 @@ void eshkol_language_coverage_vm_dispatch(const char* name,
 /** Record a validated direct Scheme closure call from serialized VM bytecode.
  * The stable hash is resolved against the manifest with collision rejection. */
 void eshkol_language_coverage_vm_call_hash(uint32_t name_hash);
+/**
+ * Record that the bytecode VM EXECUTED a compiled language form.
+ *
+ * The two hooks above only ever fire from builtin dispatch, so every
+ * construct the VM compiler lowers inline -- the arithmetic and comparison
+ * opcodes, `if`/`let`/`cond`/`do`/`lambda` and the rest of the special
+ * forms -- produced no VM evidence at all and could never earn cross-engine
+ * differential credit no matter how many programs exercised it. The VM
+ * compiler emits an OP_LANGUAGE_COVERAGE_FORM marker at the head of every
+ * compiled `(name ...)` form when tracing is armed, and reaching that marker
+ * at run time is what calls this. The stable hash is resolved against the
+ * manifest with collision rejection, exactly as for a validated call.
+ */
+void eshkol_language_coverage_vm_form_hash(uint32_t name_hash);
 /** Flush a pending opt-in language-coverage batch before exec/early exit. */
 void eshkol_language_coverage_flush(void);
 

--- a/lib/backend/eshkol_compiler.c
+++ b/lib/backend/eshkol_compiler.c
@@ -88,7 +88,9 @@ typedef enum {
     OP_RAISE_SECONDARY=69,
 
     OP_TAIL_CALL_POPN=70,
-    OP_COUNT=71
+    /* Opt-in per-form execution coverage marker; see vm_core.c. */
+    OP_LANGUAGE_COVERAGE_FORM=71,
+    OP_COUNT=72
 } OpCode;
 
 typedef struct { uint8_t op; int32_t operand; } Instr;

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -181,6 +181,7 @@ static void vm_language_coverage_native_dispatch(VM* vm, int native_id);
 static int vm_language_coverage_compilation_enabled(void);
 static uint32_t vm_language_coverage_name_hash(const char* name);
 static void vm_language_coverage_named_call(VM* vm, Value func);
+static void vm_language_coverage_form(int name_hash);
 
 /* Compiler-only promise helpers.  They intentionally have no BUILTINS[]
  * spelling: public delay/force/make-promise/promise? forms lower to them. */
@@ -1053,6 +1054,18 @@ static void vm_language_coverage_native_dispatch(VM* vm, int native_id) {
 #endif
 }
 
+/* Reached only when the compiler armed the marker, i.e. when tracing was on
+ * at compile time. Executing the marker IS the evidence: it sits at the head
+ * of the compiled form, so an untaken branch never reports its constructs. */
+static void vm_language_coverage_form(int name_hash) {
+#ifndef ESHKOL_VM_WASM
+    if (name_hash <= 0) return;
+    eshkol_language_coverage_vm_form_hash((uint32_t)name_hash);
+#else
+    (void)name_hash;
+#endif
+}
+
 static void vm_language_coverage_named_call(VM* vm, Value func) {
 #ifndef ESHKOL_VM_WASM
     if (!vm || func.type != VAL_CLOSURE || vm->pc < 2 || vm->pc > vm->code_len)
@@ -1542,7 +1555,7 @@ static int compile_and_run(const char* source) {
         "PAIRP","NUMP","STRP","BOOLP","PROCP","VECP",
         "SETCR","SETCD","POPN","OCLOS","CCALL","IVCC",
         "GUARD","UNGRD","GETXN","PKRST","WNDPS","WNDPP","VOID","LCOV","LCAL",
-        "GMARK","CLOSL","CLOSC","RAISE_SECONDARY","TCALL_POPN"
+        "GMARK","CLOSL","CLOSC","RAISE_SECONDARY","TCALL_POPN","LFORM"
     };
     const size_t opn_count = sizeof(opn) / sizeof(opn[0]);
     for (int i = 0; i < main_chunk.code_len; i++) {
@@ -2229,6 +2242,12 @@ static int eshkol_vm_validate_module_profile(const EskbModule* mod) {
                  mod->opcodes[pc + 1] != OP_TAIL_CALL)) {
                 return -1;
             }
+            break;
+        case OP_LANGUAGE_COVERAGE_FORM:
+            /* A form marker precedes an arbitrary lowering, so there is no
+             * successor opcode to validate; the operand is the stable
+             * non-negative 31-bit head-symbol hash and nothing else. */
+            if (operand <= 0) return -1;
             break;
         default:
             break;

--- a/lib/backend/sdnc_isa.h
+++ b/lib/backend/sdnc_isa.h
@@ -38,8 +38,9 @@
  * headers like eskb_format.h and vm_numeric.h.
  *
  * IMPORTANT -- this is NOT the production bytecode VM's instruction set. The
- * production VM (`lib/backend/vm_core.c`) is a separate 66-opcode ISA whose
- * values 64/65 are `OP_LANGUAGE_COVERAGE`/`OP_LANGUAGE_COVERAGE_CALL`, and it
+ * production VM (`lib/backend/vm_core.c`) is a separate 72-opcode ISA whose
+ * values 64/65/71 are `OP_LANGUAGE_COVERAGE`/`OP_LANGUAGE_COVERAGE_CALL`/
+ * `OP_LANGUAGE_COVERAGE_FORM`, and it
  * collides irreconcilably with the AD band defined here. The two instruction
  * sets are deliberately distinct and must not be merged. Likewise the
  * `TYPE_*` tags below are the float state-vector encoding used by the weight

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -4351,6 +4351,31 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
     }
     if (!node) return;
 
+    /* ── Opt-in per-form EXECUTION coverage (D-03) ──────────────────────────
+     * The VM's other two coverage markers fire only from builtin dispatch, so
+     * every construct lowered inline here — the arithmetic and comparison
+     * opcode fast paths, and `if`/`let`/`cond`/`do`/`lambda` and the rest of
+     * the special forms — emitted NO VM evidence at all. `(display (+ 1 2))`
+     * produced no trace file whatsoever, while native recorded six records
+     * for the same program, so the cross-engine differential gate could never
+     * credit `+`, `-`, `*` or any special form no matter how many programs
+     * exercised them.
+     *
+     * The marker goes at the HEAD of the form, before its operands: reaching
+     * it means control actually entered this construct, so an untaken branch
+     * still earns nothing. It is emitted only when
+     * ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR was set at compile time, which is the
+     * same switch the native engine's instrumentation honours; normal
+     * compilation emits no extra instruction. It precedes the macro check so a
+     * macro use is recorded under its own name as well as its expansion. */
+    if (node->type == N_LIST && node->n_children > 0 &&
+        node->children[0]->type == N_SYMBOL && node->children[0]->symbol &&
+        vm_language_coverage_compilation_enabled()) {
+        uint32_t form_hash =
+            vm_language_coverage_name_hash(node->children[0]->symbol);
+        if (form_hash) chunk_emit(c, OP_LANGUAGE_COVERAGE_FORM, (int)form_hash);
+    }
+
     /* Check for macro expansion — must come before all other dispatch */
     if (node->type == N_LIST && node->n_children > 0 &&
         node->children[0]->type == N_SYMBOL) {

--- a/lib/backend/vm_core.c
+++ b/lib/backend/vm_core.c
@@ -136,7 +136,18 @@ typedef enum {
     OP_RAISE_SECONDARY = 69,
 
     OP_TAIL_CALL_POPN = 70,
-    OP_COUNT = 71
+
+    /* Opt-in EXECUTION marker at the head of a compiled `(name ...)` form.
+     * Its operand is the same stable 31-bit FNV-1a hash of the head symbol
+     * that OP_LANGUAGE_COVERAGE_CALL carries. OP_LANGUAGE_COVERAGE and
+     * OP_LANGUAGE_COVERAGE_CALL only ever fire from builtin dispatch, so the
+     * arithmetic/comparison opcode fast paths and every inline special form
+     * emitted no VM evidence at all and could never earn cross-engine
+     * differential credit. This marker is what the VM compiler emits for
+     * every lowered form; reaching it is execution evidence for that
+     * construct. Normal compilation never emits this opcode. */
+    OP_LANGUAGE_COVERAGE_FORM = 71,
+    OP_COUNT = 72
 } OpCode;
 
 typedef struct { uint8_t op; int32_t operand; } Instr;

--- a/lib/backend/vm_parallel.c
+++ b/lib/backend/vm_parallel.c
@@ -696,6 +696,7 @@ static int vm_opcode_is_worker_safe(Instr instr) {
         case OP_VOID:
         case OP_LANGUAGE_COVERAGE:
         case OP_LANGUAGE_COVERAGE_CALL:
+        case OP_LANGUAGE_COVERAGE_FORM:
             return 1;
         case OP_NATIVE_CALL:
             return vm_native_is_worker_safe(instr.operand);

--- a/lib/backend/vm_run.c
+++ b/lib/backend/vm_run.c
@@ -179,6 +179,7 @@ void vm_run(VM* vm) {
         [OP_VOID]          = &&lbl_VOID,
         [OP_LANGUAGE_COVERAGE] = &&lbl_LANGUAGE_COVERAGE,
         [OP_LANGUAGE_COVERAGE_CALL] = &&lbl_LANGUAGE_COVERAGE_CALL,
+        [OP_LANGUAGE_COVERAGE_FORM] = &&lbl_LANGUAGE_COVERAGE_FORM,
         [OP_GLOBAL_MARK]   = &&lbl_GLOBAL_MARK,
         [OP_RAISE_SECONDARY] = &&lbl_RAISE_SECONDARY,
     };
@@ -572,6 +573,10 @@ void vm_run(VM* vm) {
     lbl_LANGUAGE_COVERAGE_CALL:
         vm->language_coverage_call_hash = (uint32_t)instr.operand;
         vm->language_coverage_call_pc = vm->pc;
+        DISPATCH();
+
+    lbl_LANGUAGE_COVERAGE_FORM:
+        vm_language_coverage_form(instr.operand);
         DISPATCH();
 
     lbl_HALT:
@@ -1069,6 +1074,10 @@ vm_exit:
         case OP_LANGUAGE_COVERAGE_CALL:
             vm->language_coverage_call_hash = (uint32_t)instr.operand;
             vm->language_coverage_call_pc = vm->pc;
+            break;
+
+        case OP_LANGUAGE_COVERAGE_FORM:
+            vm_language_coverage_form(instr.operand);
             break;
 
         case OP_HALT:

--- a/lib/core/runtime_language_coverage_hosted.cpp
+++ b/lib/core/runtime_language_coverage_hosted.cpp
@@ -264,6 +264,16 @@ extern "C" void eshkol_language_coverage_vm_call_hash(uint32_t name_hash) {
     sink.write(record.str());
 }
 
+extern "C" void eshkol_language_coverage_vm_form_hash(uint32_t name_hash) {
+    CoverageTrace& sink = trace();
+    if (!sink.enabled) return;
+    const char* marker = "@form";
+    if (!firstExecutionAtSite({"<vm>", marker, 0, 0, name_hash, 'V'})) return;
+    std::ostringstream record;
+    record << "V\t<vm>\t0\t0\t" << name_hash << "\t@form";
+    sink.write(record.str());
+}
+
 extern "C" void eshkol_language_coverage_flush(void) {
     trace().flush();
 }

--- a/scripts/language_coverage.py
+++ b/scripts/language_coverage.py
@@ -234,7 +234,15 @@ def load_runtime_evidence(trace_dirs):
                 if kind == "P":
                     parsed.append((location, fields[5]))
                 elif kind == "V":
-                    if fields[5] == "@call":
+                    # "@call" is a validated closure call; "@form" is the
+                    # per-form OP_LANGUAGE_COVERAGE_FORM marker the VM
+                    # compiler emits at the head of every lowered
+                    # `(name ...)`. Both carry a stable head-symbol HASH in
+                    # the operation field rather than a spelling, because the
+                    # marker has to survive ESKB serialization; both are
+                    # resolved against the manifest below, with collision
+                    # rejection.
+                    if fields[5] in ("@call", "@form"):
                         vm_call_hashes.add(operation)
                     else:
                         vm_calls.add(fields[5])

--- a/scripts/run_engine_parity_coverage.py
+++ b/scripts/run_engine_parity_coverage.py
@@ -34,8 +34,11 @@ What this does
 Both engines already carry per-construct execution instrumentation, keyed on
 $ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR (native emits `P <file> <line> <col> <id>
 <name>` records; the VM emits `V <vm> 0 0 <id> <name>` from
-vm_language_coverage_native_dispatch / _named_call).  This runs each corpus
-program under BOTH engines with tracing on, then:
+vm_language_coverage_native_dispatch and `V <vm> 0 0 <hash> @call|@form` from
+_named_call / the per-form OP_LANGUAGE_COVERAGE_FORM marker, whose stable
+head-symbol hash is resolved back to a spelling here with collision
+rejection).  This runs each corpus program under BOTH engines with tracing on,
+then:
 
   1. compares normalised stdout — a mismatch is a DIVERGENCE, reported by
      program and by the constructs that program exercised;
@@ -126,7 +129,42 @@ def normalise(text):
     return "".join(keep)
 
 
-def read_constructs(trace_dir):
+def vm_name_hash(name):
+    """The VM compiler's stable non-negative 31-bit FNV-1a head-symbol hash.
+
+    Mirrors vm_language_coverage_name_hash() in lib/backend/eshkol_vm.c and
+    vm_call_name_hash() in scripts/language_coverage.py. The VM records a
+    hash, not a spelling, because the marker must survive ESKB serialization.
+    """
+    value = 2166136261
+    for byte in name.encode("utf-8"):
+        value ^= byte
+        value = (value * 16777619) & 0xFFFFFFFF
+    return value & 0x7FFFFFFF
+
+
+def build_hash_index(surface):
+    """Resolve VM hash markers to surface names, refusing collisions.
+
+    An ambiguous hash can never grant credit: two constructs sharing one
+    marker would let evidence for either be attributed to both.
+    """
+    by_hash = {}
+    for name in surface:
+        by_hash.setdefault(vm_name_hash(name), set()).add(name)
+    return {value: next(iter(names))
+            for value, names in by_hash.items() if len(names) == 1}
+
+
+# VM markers that carry a head-symbol HASH in the operation field and a fixed
+# marker word where a native record carries the spelling: "@call" is a
+# validated closure call, "@form" (OP_LANGUAGE_COVERAGE_FORM) is any compiled
+# form the VM executed, which is what gives inline opcode fast paths and
+# special forms their differential evidence.
+VM_HASH_MARKERS = ("@call", "@form")
+
+
+def read_constructs(trace_dir, hash_index):
     """Construct names recorded by either engine's coverage instrumentation."""
     names = set()
     for path in glob.glob(os.path.join(trace_dir, "*")):
@@ -134,11 +172,22 @@ def read_constructs(trace_dir):
             with open(path, encoding="utf-8", errors="replace") as f:
                 for line in f:
                     parts = line.rstrip("\n").split("\t")
-                    # native: P <file> <line> <col> <id> <name>
-                    # vm    : V <vm>   0      0     <id> <name>
-                    if len(parts) >= 6 and parts[0] in ("P", "V"):
-                        if parts[5]:
-                            names.add(parts[5])
+                    # native: P <file> <line> <col> <id>   <name>
+                    # vm    : V <vm>   0      0     <id>   <name>
+                    # vm    : V <vm>   0      0     <hash> @call|@form
+                    if len(parts) < 6 or parts[0] not in ("P", "V"):
+                        continue
+                    if parts[0] == "V" and parts[5] in VM_HASH_MARKERS:
+                        try:
+                            marker = int(parts[4])
+                        except ValueError:
+                            continue
+                        resolved = hash_index.get(marker)
+                        if resolved:
+                            names.add(resolved)
+                        continue
+                    if parts[5]:
+                        names.add(parts[5])
         except OSError:
             continue
     return names
@@ -226,6 +275,7 @@ def main():
     }
     high_risk_surface = {name for name in surface
                          if categories.get(name) in high_risk_categories}
+    hash_index = build_hash_index(surface)
 
     patterns = args.corpus or DEFAULT_CORPUS
     programs = []
@@ -285,8 +335,8 @@ def main():
                        {"ESHKOL_JIT_CACHE": "0"}, args.timeout)
             run_engine([VM_BIN], prog, vd,
                        {"ESHKOL_VM_NO_DISASM": "1"}, args.timeout)
-            n_constructs = read_constructs(nd)
-            v_constructs = read_constructs(vd)
+            n_constructs = read_constructs(nd, hash_index)
+            v_constructs = read_constructs(vd, hash_index)
         else:
             scratch = os.path.join(REPO, ".scratch", "engine-parity")
             os.makedirs(scratch, exist_ok=True)
@@ -296,8 +346,8 @@ def main():
                            {"ESHKOL_JIT_CACHE": "0"}, args.timeout)
                 run_engine([VM_BIN], prog, vd,
                            {"ESHKOL_VM_NO_DISASM": "1"}, args.timeout)
-                n_constructs = read_constructs(nd)
-                v_constructs = read_constructs(vd)
+                n_constructs = read_constructs(nd, hash_index)
+                v_constructs = read_constructs(vd, hash_index)
 
         if nrc != 0:
             # Native is the reference; a program native cannot run says

--- a/scripts/test_runtime_language_coverage.py
+++ b/scripts/test_runtime_language_coverage.py
@@ -17,6 +17,12 @@ SPEC = importlib.util.spec_from_file_location(
 LANGUAGE_COVERAGE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(LANGUAGE_COVERAGE)
 
+PARITY_SPEC = importlib.util.spec_from_file_location(
+    "run_engine_parity_coverage",
+    REPO / "scripts" / "run_engine_parity_coverage.py")
+ENGINE_PARITY = importlib.util.module_from_spec(PARITY_SPEC)
+PARITY_SPEC.loader.exec_module(ENGINE_PARITY)
+
 
 class RuntimeEvidencePolicyTest(unittest.TestCase):
     def synthetic_evidence(self, records):
@@ -98,6 +104,16 @@ class RuntimeEvidencePolicyTest(unittest.TestCase):
             with self.assertRaisesRegex(
                     RuntimeError, "ambiguous serialized-VM call hash"):
                 self.synthetic_evidence(["V\t<vm>\t0\t0\t77\t@call"])
+
+    def test_serialized_vm_form_marker_gets_credit(self):
+        """The per-form marker is what gives an inline opcode fast path
+        evidence: `+` never reaches a native-call or closure-call marker."""
+        marker = LANGUAGE_COVERAGE.vm_call_name_hash("+")
+        evidence = self.synthetic_evidence([
+            "V\t<vm>\t0\t0\t%d\t@form" % marker,
+        ])
+        self.assertIn("+", evidence["covered_names"])
+        self.assertIn("+", evidence["vm_dispatch_names"])
 
     def test_expected_negative_form_requires_rejection_event(self):
         parsed_only = self.synthetic_evidence([
@@ -195,6 +211,92 @@ class RuntimeInstrumentationTest(unittest.TestCase):
                         abs_sources.add(pathlib.Path(fields[1]).resolve())
             self.assertEqual(abs_sources, {imported.resolve()})
 
+    ONE_LINE_PROGRAM = '(display (+ 1 2))\n'
+
+    def vm_trace_names(self, trace_dir):
+        """Every construct the VM credited, plus the raw record kinds seen."""
+        evidence = LANGUAGE_COVERAGE.load_runtime_evidence([str(trace_dir)])
+        raw = "\n".join(path.read_text(encoding="utf-8")
+                         for path in pathlib.Path(trace_dir).glob("*.tsv"))
+        return evidence, raw
+
+    def run_standalone_vm(self, args, trace_dir, instrumented=True):
+        env = os.environ.copy()
+        env.pop("ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR", None)
+        if instrumented:
+            env["ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR"] = str(trace_dir)
+        env["ESHKOL_VM_NO_DISASM"] = "1"
+        result = subprocess.run(
+            [self.eshkol_vm] + args,
+            cwd=REPO, env=env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=120, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result
+
+    def test_standalone_vm_records_inline_form_execution(self):
+        """A one-line program used to produce NO VM trace file at all.
+
+        `display` and `+` are both lowered to inline opcode fast paths, so
+        neither reached the builtin-dispatch or closure-call marker and the
+        VM wrote nothing while native wrote six records for the same source.
+        """
+        with tempfile.TemporaryDirectory() as root:
+            root_path = pathlib.Path(root)
+            trace_dir = root_path / "trace"
+            trace_dir.mkdir()
+            source = root_path / "vm-inline-form.esk"
+            source.write_text(self.ONE_LINE_PROGRAM, encoding="utf-8")
+            self.run_standalone_vm([str(source)], trace_dir)
+            evidence, raw = self.vm_trace_names(trace_dir)
+            self.assertTrue(
+                any(line.startswith("V\t") for line in raw.splitlines()),
+                "the standalone VM binary wrote no V record: %r" % raw)
+            self.assertIn("+", evidence["vm_dispatch_names"])
+            self.assertIn("display", evidence["vm_dispatch_names"])
+
+    def test_hosted_vm_profile_records_inline_form_execution(self):
+        """The same contract across ESKB serialization, which is the route
+        the release parity gate and CI's VM lanes actually take."""
+        with tempfile.TemporaryDirectory() as root:
+            root_path = pathlib.Path(root)
+            trace_dir = root_path / "trace"
+            trace_dir.mkdir()
+            source = root_path / "vm-inline-form-profile.esk"
+            module = root_path / "vm-inline-form-profile.eskb"
+            source.write_text(self.ONE_LINE_PROGRAM, encoding="utf-8")
+            env = os.environ.copy()
+            env["ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR"] = str(trace_dir)
+            compiled = subprocess.run(
+                [self.eshkol_run, "--profile", "hosted-vm", "--emit-eskb",
+                 str(module), str(source)],
+                cwd=REPO, env=env, text=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                timeout=120, check=False,
+            )
+            self.assertEqual(compiled.returncode, 0,
+                             compiled.stdout + compiled.stderr)
+            self.run_standalone_vm([str(module)], trace_dir)
+            evidence, raw = self.vm_trace_names(trace_dir)
+            self.assertIn("\t%d\t@form" % LANGUAGE_COVERAGE.vm_call_name_hash("+"),
+                          raw)
+            self.assertIn("+", evidence["vm_dispatch_names"])
+            self.assertIn("display", evidence["vm_dispatch_names"])
+
+    def test_vm_unset_environment_emits_no_trace(self):
+        """Instrumentation stays opt-in: an unset trace dir must leave the
+        compiled bytecode and the filesystem exactly as they were."""
+        with tempfile.TemporaryDirectory() as root:
+            root_path = pathlib.Path(root)
+            trace_dir = root_path / "trace"
+            trace_dir.mkdir()
+            source = root_path / "vm-inline-form-off.esk"
+            source.write_text(self.ONE_LINE_PROGRAM, encoding="utf-8")
+            self.run_standalone_vm([str(source)], trace_dir,
+                                   instrumented=False)
+            self.assertEqual(list(trace_dir.iterdir()), [])
+
     def test_serialized_vm_dispatch_preserves_exact_aliases(self):
         with tempfile.TemporaryDirectory() as root:
             root_path = pathlib.Path(root)
@@ -278,6 +380,53 @@ class RuntimeInstrumentationTest(unittest.TestCase):
                 path.read_text(encoding="utf-8")
                 for path in trace_dir.glob("*.tsv"))
             self.assertIn("\t%s\t@call" % marker, raw_trace)
+
+
+class EngineParityMarkerResolutionTest(unittest.TestCase):
+    """The differential gate must read the VM's hash markers.
+
+    The VM records a stable head-symbol hash, not a spelling, so a gate that
+    reads field 6 literally sees "@call"/"@form" and credits nothing — which
+    is exactly why `+`, `-` and `*` sat in high_risk_uncovered while the VM
+    was executing them.
+    """
+
+    def resolve(self, records):
+        surface = {"+", "display", "if", "let"}
+        index = ENGINE_PARITY.build_hash_index(surface)
+        with tempfile.TemporaryDirectory() as trace_dir:
+            pathlib.Path(trace_dir, "language-coverage-1.tsv").write_text(
+                "\n".join(records) + "\n", encoding="utf-8")
+            return ENGINE_PARITY.read_constructs(trace_dir, index)
+
+    def test_form_and_call_markers_resolve_to_names(self):
+        names = self.resolve([
+            "V\t<vm>\t0\t0\t%d\t@form" % ENGINE_PARITY.vm_name_hash("+"),
+            "V\t<vm>\t0\t0\t%d\t@call" % ENGINE_PARITY.vm_name_hash("let"),
+        ])
+        self.assertEqual(names, {"+", "let"})
+
+    def test_named_vm_dispatch_and_native_parse_records_still_read(self):
+        names = self.resolve([
+            "V\t<vm>\t0\t0\t60\tdisplay",
+            "P\ttests/x.esk\t1\t2\t7\tif",
+        ])
+        self.assertEqual(names, {"display", "if"})
+
+    def test_unknown_hash_earns_nothing(self):
+        self.assertEqual(self.resolve(["V\t<vm>\t0\t0\t12345\t@form"]), set())
+
+    def test_hash_matches_the_vm_compilers_definition(self):
+        self.assertEqual(ENGINE_PARITY.vm_name_hash("+"),
+                         LANGUAGE_COVERAGE.vm_call_name_hash("+"))
+
+    def test_colliding_surface_names_are_refused_rather_than_guessed(self):
+        index = ENGINE_PARITY.build_hash_index({"a", "b"})
+        with mock.patch.object(ENGINE_PARITY, "vm_name_hash",
+                               return_value=77):
+            colliding = ENGINE_PARITY.build_hash_index({"a", "b"})
+        self.assertEqual(colliding, {})
+        self.assertEqual(len(index), 2)
 
 
 def main():

--- a/tests/coverage/README.md
+++ b/tests/coverage/README.md
@@ -92,10 +92,15 @@ Each builtin records which backend(s) register it (`native`, `vm`,
 2. LLVM code generation records reached AST nodes (`G`) and injects lightweight
    runtime hooks into that instrumented module. Executed operations (`O`) and
    direct calls (`C`) are emitted by the running JIT/AOT program.
-3. The bytecode compiler serializes two exact dispatch witnesses. Native calls
-   carry their native-ID alias marker (`V name`), while direct Scheme closure
-   calls carry a stable 31-bit FNV-1a marker (`V hash @call`). The VM validates
-   each marker immediately beside the actual `CALL`/`TAIL_CALL` dispatch;
+3. The bytecode compiler serializes three exact execution witnesses. Native
+   calls carry their native-ID alias marker (`V name`), direct Scheme closure
+   calls carry a stable 31-bit FNV-1a marker (`V hash @call`) validated
+   immediately beside the actual `CALL`/`TAIL_CALL` dispatch, and every
+   compiled `(name ...)` form carries the same stable hash as a per-form
+   marker (`V hash @form`) at the head of its lowering. The first two fire
+   only from builtin dispatch, so before the third existed the arithmetic and
+   comparison opcode fast paths and every inline special form produced no VM
+   evidence at all — `(display (+ 1 2))` wrote no VM trace file whatsoever.
    `language_coverage.py` resolves hashes only against the checked-in manifest
    and rejects collisions rather than granting ambiguous credit.
 4. `language_coverage.py` grants ordinary builtins and runtime forms credit only
@@ -109,7 +114,9 @@ Each builtin records which backend(s) register it (`native`, `vm`,
    untaken branch has `P` and `G`, but no `O`/`C`, and is therefore uncovered.
 6. The regression test `scripts/test_runtime_language_coverage.py` exercises a
    real untaken branch, exact ESKB native aliases, exact serialized direct
-   Scheme calls, collision rejection, and an unset trace environment.
+   Scheme calls, per-form markers on both engine binaries (the standalone VM
+   and the `--profile hosted-vm` ESKB route), the differential gate's own
+   hash resolution, collision rejection, and an unset trace environment.
 
 Normal generated programs contain no hooks unless tracing was enabled in the
 compiler process. Parser dispatch has one cached false branch in production;


### PR DESCRIPTION
## What was wrong

Under `ESHKOL_LANGUAGE_COVERAGE_TRACE_DIR` the two engines are supposed to
report the same thing. They did not. `(display (+ 1 2))` made the native
engine write six coverage records and made the bytecode VM write **no trace
file at all**.

The VM had exactly two coverage markers and both fire from **builtin
dispatch**:

* `vm_language_coverage_native_dispatch`, keyed on an `OP_LANGUAGE_COVERAGE`
  marker immediately before an `OP_NATIVE_CALL`;
* `vm_language_coverage_named_call`, keyed on an `OP_LANGUAGE_COVERAGE_CALL`
  marker immediately before a `CALL`/`TAIL_CALL`.

A construct the VM compiler lowers inline reaches neither. The arithmetic and
comparison opcode fast paths, and `if`, `quote`, `let`, `cond`, `do`, `lambda`
and the rest of the special forms, are compiled straight to opcodes in
`lib/backend/vm_compiler.c`, so they could never earn cross-engine
differential credit no matter how many programs exercised them. That is the
capped-fraction defect already recorded as **D-03 (i)** in
`docs/design/FLAW_DETECTION_ROADMAP.md`; the emitter was never missing, its
coverage was.

Second, half-connected: the VM records a *hash*, not a spelling.
`scripts/run_engine_parity_coverage.py` read field 6 of a `V` record
literally, so a hash marker read as the word `@call` and credited nothing —
`scripts/language_coverage.py` had always resolved those hashes, the
differential gate never did.

## What changed

* **`OP_LANGUAGE_COVERAGE_FORM` (71)** — the VM compiler emits it at the head
  of every compiled `(name ...)` form when tracing is armed. Its operand is
  the same stable non-negative 31-bit FNV-1a head-symbol hash the call marker
  already carries, so it survives ESKB serialization: the standalone VM
  binary and the `--profile hosted-vm` route report identically. The marker
  precedes the form's operands, so reaching it means control actually entered
  that construct and an untaken branch still earns nothing.
* **Gates read what the VM writes.** `run_engine_parity_coverage.py` resolves
  `@call` and `@form` against the surface manifest with collision rejection;
  `language_coverage.py` accepts `@form` beside `@call`. The manifest's 1113
  names have no hash collisions, so no observed marker is ambiguous.
* **Regression tests** in `scripts/test_runtime_language_coverage.py`
  (ctest `runtime_language_coverage_test`): a one-line program yields a `V`
  record on the standalone VM binary and across the hosted-vm ESKB route, an
  unarmed run still writes nothing, and the differential gate's own hash
  resolution is exercised including collision refusal. All eight new tests
  fail against a binary built without this change.
* Docs updated where they described the gap or the opcode count.

## Numbers

Measured on `integration/astra-v135`, 262 programs, same binaries and corpus
before and after:

| | before | after |
|---|---|---|
| constructs with differential evidence | 194 / 1137 (17.06%) | **303 / 1137 (26.65%)** |
| high-risk constructs with evidence | 102 / 473 (21.56%) | **152 / 473 (32.14%)** |

Programs both engines ran clean: 183. Native-only: 63. Divergent: 5 (all
baselined). Regressed: 2 — `r7rs_import_modifier_test` and
`parallel_ad_worker_init_test`, unchanged by this PR and owned by another
lane.

## This does not make the gate green, and cannot

The recorded `high_risk_differential_floor` is `1.00`. Running the **native
engine alone** over the gate's default corpus, the parser records only
**171 of the 473 high-risk constructs (36.15%)**. A construct no corpus
program mentions can never earn differential credit on either engine, so
36.15% is the arithmetic ceiling on today's corpus and 100% is unreachable
regardless of VM instrumentation. This change reaches 89% of that ceiling.

That floor was never a measurement: `--update-baseline` writes the literal
`1.0` rather than the observed fraction, which is why the sub-gate has been
red since it was added (`4b32ed17`, on this integration branch only —
`origin/master` has neither the high-risk gate nor the key). **The floor is
left exactly where it is.** Closing the remainder is corpus work: 190
`tensor_ad`, 55 `geometry`, 36 `numeric`, 10 `consciousness`, 6
`memory_region`, 3 `macro_syntax` and 2 `control_flow` high-risk constructs
that no program in the differential corpus mentions on either engine.

## Verification

* `scripts/test_runtime_language_coverage.py` — 23 tests, all pass; the 8 new
  ones error against the pre-change binaries.
* `ctest -R "coverage|vm_parity|language"` — 2/2 pass.
* `./scripts/run_all_tests.sh` — every suite, 100%, exit 0.
* `python3 scripts/check_wasm_imports.py --build-dir build` — OK, 122 env
  imports all provided (the marker is compiled out under `ESHKOL_VM_WASM`).
* Instrumentation is behaviour-neutral: all 262 corpus programs give
  byte-identical VM stdout and exit status armed and unarmed. Bytecode grows
  ~26% only while armed (93,043 → 116,925 instructions on the largest corpus
  program, against a 1,000,000 ceiling).
* `language_coverage.py` over an armed native+VM trace set reports the same
  298/1113 with and without the `@form` records, so the 100% execution
  coverage gate is unaffected.
