### PR TITLE
Restore VM parity for built-in library imports and captured values in parallel workers

### DIFF
--- a/inc/eshkol/builtin_libraries.h
+++ b/inc/eshkol/builtin_libraries.h
@@ -1,0 +1,51 @@
+#ifndef ESHKOL_BUILTIN_LIBRARIES_H
+#define ESHKOL_BUILTIN_LIBRARIES_H
+
+#include <stddef.h>
+#include <string.h>
+
+/*
+ * The ONE table of R7RS library names Eshkol satisfies from a built-in module
+ * instead of from a source file on the load path.
+ *
+ * `(import (scheme base) …)` names a library that has no `scheme/base.esk` to
+ * find, so an engine that hands the joined name straight to the source-file
+ * resolver reports `module source not found: scheme.base` and refuses the
+ * program.  Both engines therefore map the library name through this table
+ * FIRST: the native front end in join_r7rs_library_name() (lib/frontend/
+ * parser.cpp) and the bytecode VM in vm_library_name_from_datum()
+ * (lib/backend/vm_compiler.c).  Adding a built-in library means adding one row
+ * here — there is deliberately no second list for either engine to drift from.
+ *
+ * Header-only and free of allocation so the VM's C unity build and the WASM
+ * VM (which does not link the C++ platform runtime) can consult it too.
+ */
+
+typedef struct {
+    const char* library; /* dotted R7RS library name, e.g. "scheme.base" */
+    const char* module;  /* internal Eshkol module that provides it       */
+} EshkolBuiltinLibrary;
+
+static const EshkolBuiltinLibrary eshkol_builtin_libraries[] = {
+    { "scheme.base", "stdlib" }
+};
+
+#define ESHKOL_N_BUILTIN_LIBRARIES \
+    ((int)(sizeof(eshkol_builtin_libraries) / sizeof(eshkol_builtin_libraries[0])))
+
+/**
+ * @brief The built-in module that provides dotted library name @p library, or
+ *        NULL when the name is not built in and must be resolved as a source
+ *        file like any other module.
+ */
+static inline const char* eshkol_builtin_library_module(const char* library) {
+    if (!library || !*library) return NULL;
+    for (int i = 0; i < ESHKOL_N_BUILTIN_LIBRARIES; i++) {
+        if (strcmp(eshkol_builtin_libraries[i].library, library) == 0) {
+            return eshkol_builtin_libraries[i].module;
+        }
+    }
+    return NULL;
+}
+
+#endif /* ESHKOL_BUILTIN_LIBRARIES_H */

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -1,3 +1,4 @@
+#include <eshkol/builtin_libraries.h>
 #include <eshkol/module_resolver.h>
 static void compile_expr_impl(FuncChunk* c, Node* node, int tail);
 static void compile_expr(FuncChunk* c, Node* node, int tail);
@@ -1081,6 +1082,13 @@ static int vm_collect_module_form_exports(Node** forms, int n_forms,
  * R7RS permits exact non-negative integers as name components, so an integer
  * literal is joined by its written value.
  *
+ * The joined name is then mapped through the shared built-in library table
+ * (inc/eshkol/builtin_libraries.h) — the SAME table the native front end
+ * consults in join_r7rs_library_name(). Without that step `(import (scheme
+ * base) …)` reached vm_compile_module_by_name() as the dotted name
+ * `scheme.base`, which has no source file, and the VM refused a program the
+ * native engine runs.
+ *
  * @return 1 on success, 0 if @p datum is not a well-formed library name.
  */
 static int vm_library_name_from_datum(const Node* datum, char* out, size_t out_size) {
@@ -1105,7 +1113,14 @@ static int vm_library_name_from_datum(const Node* datum, char* out, size_t out_s
         used += strlen(piece);
         out[used] = '\0';
     }
-    return used > 0;
+    if (used == 0) return 0;
+    const char* builtin = eshkol_builtin_library_module(out);
+    if (builtin) {
+        size_t builtin_len = strlen(builtin);
+        if (builtin_len + 1 > out_size) return 0;
+        memcpy(out, builtin, builtin_len + 1);
+    }
+    return 1;
 }
 
 /**

--- a/lib/backend/vm_parallel.c
+++ b/lib/backend/vm_parallel.c
@@ -489,6 +489,17 @@ static int vm_clone_object_at(VM* worker, VM* main_vm, int32_t idx,
                     return 0;
                 memcpy(dst->closure.open_slots, src->closure.open_slots,
                        (size_t)src->closure.n_upvalues * sizeof(int32_t));
+                /* The captured VALUES have to travel with the slots. `*dst =
+                 * *src` above aliased the source array, and the vm_alloc()
+                 * that just replaced it hands back uninitialised arena
+                 * memory, so without this copy every by-value capture reaches
+                 * the worker as garbage (NIL on a fresh arena page) — which
+                 * is exactly what `+: expected numeric operands` inside a
+                 * parallel-map lambda was. Heap indices stay valid across the
+                 * copy because vm_clone_value_graph() below clones each
+                 * reachable object into the worker heap at the SAME index. */
+                memcpy(dst->closure.upvalues, src->closure.upvalues,
+                       (size_t)src->closure.n_upvalues * sizeof(Value));
             }
             for (int i = 0; i < src->closure.n_upvalues; i++) {
                 /* Escaped top-level captures are represented by an absolute

--- a/lib/frontend/parser.cpp
+++ b/lib/frontend/parser.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  *
  */
+#include <eshkol/builtin_libraries.h>
 #include <eshkol/core/ast_routing.h>
 #include <eshkol/eshkol.h>
 #include <eshkol/core/logic.h>
@@ -4118,19 +4119,22 @@ static char* parser_copy_cstr(const std::string& value) {
 /**
  * @brief Joins an R7RS library-name's symbol @p parts (e.g. `(foo bar baz)`) into an internal module-name string.
  *
- * Special-cases the standard `(scheme base)` library name, mapping it to
- * Eshkol's built-in "stdlib" module; otherwise joins the parts with `.`
- * (e.g. `(foo bar baz)` becomes `"foo.bar.baz"`).
+ * Parts are joined with `.` (e.g. `(foo bar baz)` becomes `"foo.bar.baz"`),
+ * then mapped through the shared built-in library table
+ * (inc/eshkol/builtin_libraries.h) so a library Eshkol provides itself —
+ * `(scheme base)` — becomes its built-in module name instead of a source file
+ * nobody can find. The bytecode VM consults the SAME table in
+ * vm_library_name_from_datum(), which is what keeps the two engines agreeing
+ * on which libraries exist without a source file.
  */
 static std::string join_r7rs_library_name(const std::vector<std::string>& parts) {
-    if (parts.size() == 2 && parts[0] == "scheme" && parts[1] == "base") {
-        return "stdlib";
-    }
-
     std::string out;
     for (size_t i = 0; i < parts.size(); i++) {
         if (i > 0) out += ".";
         out += parts[i];
+    }
+    if (const char* builtin = eshkol_builtin_library_module(out.c_str())) {
+        return std::string(builtin);
     }
     return out;
 }

--- a/tests/vm_parity/corpus/82_scheme_base_builtin_import.esk
+++ b/tests/vm_parity/corpus/82_scheme_base_builtin_import.esk
@@ -1,0 +1,13 @@
+; (scheme base) is a BUILT-IN library: it has no source file on the load path,
+; so both engines must map the library name through the shared built-in table
+; (inc/eshkol/builtin_libraries.h) instead of handing `scheme.base` to the
+; source-file resolver, which refuses the program. The import modifiers wrap
+; the library name, so each one has to reach that same mapping.
+(import (scheme base))
+(import (only (scheme base) + -))
+(import (except (scheme base) not-an-export))
+
+(display (and (= (+ 2 3) 5)
+              (= (- 9 4) 5)
+              (= (* 3 4) 12)))
+(newline)

--- a/tests/vm_parity/corpus/83_parallel_map_captured_upvalue.esk
+++ b/tests/vm_parity/corpus/83_parallel_map_captured_upvalue.esk
@@ -1,0 +1,27 @@
+; A parallel-map lambda that CAPTURES an enclosing binding: the VM runs a
+; worker-safe closure in an isolated worker VM with a private heap, so the
+; captured values have to travel with the cloned closure. A worker that gets a
+; fresh, uninitialised capture array sees NIL instead of the captured number
+; and the body fails with `+: expected numeric operands`, while native returns
+; the right answer — the exact shape this pins.
+(define inputs (list 1 2 3 4 5 6 7 8))
+
+(define (offset-squares k)
+  (parallel-map (lambda (x) (+ (* x x) k)) inputs))
+
+(define (constant-of k)
+  (parallel-map (lambda (x) k) inputs))
+
+(define nested
+  (let loop ((i 0) (acc '()))
+    (if (>= i 3)
+        (reverse acc)
+        (loop (+ i 1) (cons (apply + (parallel-map (lambda (x) (+ x i)) inputs))
+                            acc)))))
+
+(display (offset-squares 100))
+(newline)
+(display (constant-of 7))
+(newline)
+(display nested)
+(newline)


### PR DESCRIPTION
Two programs that the engine-parity gate (`scripts/run_engine_parity_coverage.py`) recorded as running clean on both engines had stopped running on the bytecode VM while native still passed. Both are fixed at the root; neither program is reclassified or special-cased.

## 1. `(scheme base)` is a built-in library, and only one engine knew it

`tests/parser/r7rs_import_modifier_test.esk`

```
ERROR: module source not found: scheme.base
ERROR:   load/require must resolve an existing source file
ERROR: refusing to run a program that failed to compile
```

`(import (scheme base) …)` names a library Eshkol provides itself — there is no `scheme/base.esk` to find. The native front end knew that: `join_r7rs_library_name()` in `lib/frontend/parser.cpp` mapped the joined name to the built-in `stdlib` module. The VM had no such knowledge, so as soon as its module loading went through the shared source resolver and started refusing an unresolvable module (`68e2c036`, `fix(vm): semantics audit fixes (SW-91/92)`), every `(scheme base)` import failed to compile. Before that commit the VM's loader silently ignored a missing module file, which is why the program appeared to work: the import resolved to nothing and the prelude supplied `+` anyway.

Refusing an unresolvable module is right; the missing piece was that the set of built-in libraries lived in one engine only. It is now a single table — `inc/eshkol/builtin_libraries.h` — consulted by both: the native front end in `join_r7rs_library_name()` and the VM in `vm_library_name_from_datum()`. Adding a built-in library is one row there. Because the VM maps the name where it joins the library-name datum, every R7RS import modifier reaches it: `only`, `except`, `prefix` and `rename` all wrap the library name `vm_import_set_library_datum()` peels down to.

## 2. A cloned worker closure lost the values it captured

`tests/v1_2_edge_cases/parallel_ad_worker_init_test.esk`

```
ERROR: unhandled exception: error: +: expected numeric operands   (× once per task)
```

A worker-safe closure handed to `parallel-map` runs in an isolated worker VM with its own heap, so `vm_clone_object_at()` clones it there. Since `91e279dd` gave capture storage a dynamic size, the clone allocates a *fresh* upvalues array for the worker — replacing the pointer `*dst = *src` had aliased — and then never copies the captured values into it. Only the open-slot array was copied. Every by-value capture therefore reached the worker as whatever the fresh arena page held: `'()` on a zeroed page, garbage otherwise.

```scheme
(define (f i) (parallel-map (lambda (x) (+ x i)) xs))
```

read `i` as `'()` inside the worker and raised `+: expected numeric operands` once per task. On `origin/master` the same defect is present with a non-zero page and the program does not merely misbehave — it dies (exit 138); the candidate's open-slot copy (`1418c5da`) changed the symptom to the clean per-task error.

The fix copies the captured values alongside the open slots. Heap indices survive the copy unchanged because `vm_clone_value_graph()` clones each reachable object into the worker heap at the **same** index — the contract the loop underneath already relies on.

## Corpus

Two differential-corpus entries pin the shapes rather than the two test files:

* `tests/vm_parity/corpus/82_scheme_base_builtin_import.esk` — plain, `only` and `except` imports of `(scheme base)`.
* `tests/vm_parity/corpus/83_parallel_map_captured_upvalue.esk` — `parallel-map` lambdas capturing an enclosing binding, including a named-let loop variable.

## Verification

| gate | result |
| --- | --- |
| both programs on JIT / AOT / VM | pass on all three |
| `run_engine_parity_coverage.py` | **REGRESSED programs: 0**; divergent 5 (baseline allows 7, none new); differential coverage 17.24% vs floor 13.35% |
| `check_engine_parity_threshold.py` | red only on the aspirational `high_risk_differential_floor` (1.00 by construction — `run_engine_parity_coverage.py` writes it as `1.0` unconditionally, so it has never been green); `regressed_programs = 0` |
| `scripts/run_vm_parity.sh` | 288 passed, 0 failed, 0 infra |
| `ctest -R "vm\|parity\|import\|parallel\|module"` | 55/55 passed |
| `scripts/run_all_tests.sh` | 44/44 suites, Suite Pass Rate 100% |
| `scripts/check_wasm_imports.py --build-dir build` | OK — 12 surfaces, 122 env imports, all provided |
