### PR TITLE
Disable FP contraction so native and WASM evaluate binary64 identically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,27 @@ that the candidate has passed its release gates.
 
 ### Fixed
 
+- **The same C kernel computed different binary64 bits on native and on
+  WebAssembly, because the compiler was allowed to fuse a multiply into an
+  add.** The forward-mode dual quotient rule
+  (`a.tangent * inv - a.primal * b.tangent * inv2`), shared by
+  `eshkol_tensor_layer_norm_dual` and the VM's `vm_tensor_dual_div`, was
+  compiled to a fused multiply-add on AArch64 and x86-64-with-FMA — one
+  rounding — and to a separate multiply and subtract on WebAssembly, whose
+  instruction set has no scalar f64 FMA — two roundings. The layer-norm tangent
+  in `tests/vm_parity/corpus/551_tensor_transformer_dual.esk` came out
+  `0.20413179969792875` on native and `0.20413179969792872` under the WASM VM,
+  and the execute-and-diff lane failed on the last digit of one printed double.
+
+  Contraction is a per-target liberty, so leaving it at the compiler default
+  makes cross-engine parity depend on which instructions the back end happens
+  to have. The build now compiles every translation unit with
+  `-ffp-contract=off`, and `scripts/run_wasm_differential.sh` passes the same
+  flag to Emscripten, so both engines evaluate binary64 arithmetic exactly as
+  written; a kernel that wants a fused, singly-rounded product asks for it with
+  an explicit `fma()`. `docs/VM_PARITY.md` records the rule as part of the
+  parity contract.
+
 - **Two of the four cond-clause shapes R7RS allows inside `guard` were silently
   wrong, on the native backend and the bytecode VM alike** (`SW-78`, `SW-79`).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,50 @@ if(MSVC)
     set(ESHKOL_USING_MSVC TRUE)
 endif()
 
+# ── cross-engine floating-point determinism ───────────────────────────────
+# Eshkol promises that the native LLVM codegen, the bytecode VM and the
+# WebAssembly build of that VM compute the same IEEE-754 binary64 bits for the
+# same program (docs/VM_PARITY.md; gated by scripts/run_vm_parity.sh and
+# scripts/run_wasm_differential.sh).  Fusing `a * b + c` into a single
+# multiply-add is a per-target liberty, not a per-language one: AArch64 and
+# x86-64-with-FMA fuse it and round once, while WebAssembly has no scalar f64
+# FMA instruction and must round twice.  At the compiler default
+# (`-ffp-contract=on`) one and the same C kernel therefore yields different
+# bits on different engines — which is exactly how the forward-dual quotient
+# rule in the layer-norm AD kernel came to differ by one ulp between native
+# and WASM (tests/vm_parity/corpus/551_tensor_transformer_dual.esk).
+#
+# The parity contract is "evaluate binary64 arithmetic as written", so
+# contraction is switched off for every translation unit of the project.  A
+# kernel that WANTS a fused, singly-rounded product spells it with an explicit
+# `fma()` call, which is contraction-independent and identical on every
+# engine.  The WASM build of the VM carries the same flag
+# (scripts/run_wasm_differential.sh) so the two sides stay explicit rather
+# than accidentally agreeing.
+include(CheckCCompilerFlag)
+set(ESHKOL_FP_CONTRACT_FLAG "")
+if(ESHKOL_USING_MSVC)
+    # clang-cl (the only Windows front end Eshkol builds with) takes GCC-style
+    # options through the `/clang:` escape hatch.
+    check_c_compiler_flag("/clang:-ffp-contract=off" ESHKOL_HAVE_CLANGCL_FP_CONTRACT)
+    if(ESHKOL_HAVE_CLANGCL_FP_CONTRACT)
+        set(ESHKOL_FP_CONTRACT_FLAG "/clang:-ffp-contract=off")
+    endif()
+else()
+    check_c_compiler_flag("-ffp-contract=off" ESHKOL_HAVE_FP_CONTRACT_OFF)
+    if(ESHKOL_HAVE_FP_CONTRACT_OFF)
+        set(ESHKOL_FP_CONTRACT_FLAG "-ffp-contract=off")
+    endif()
+endif()
+if(ESHKOL_FP_CONTRACT_FLAG)
+    add_compile_options("${ESHKOL_FP_CONTRACT_FLAG}")
+else()
+    message(WARNING
+        "This compiler does not accept an -ffp-contract=off spelling. Fused "
+        "multiply-add contraction stays enabled, and cross-engine binary64 "
+        "parity (docs/VM_PARITY.md) is not guaranteed for this build.")
+endif()
+
 set(ESHKOL_CLANG_BUILTINS_LIB "")
 set(ESHKOL_EXTRA_LINK_LIBS "")
 set(ESHKOL_HOST_CXX_COMPILER_EXPLICIT FALSE)

--- a/docs/VM_PARITY.md
+++ b/docs/VM_PARITY.md
@@ -202,5 +202,39 @@ normalized agreement fails the gate until the program is moved to
 `tests/vm_parity/resolved/` or promoted into `corpus/`. This keeps the active
 contract precise without retaining stale defect claims.
 
+## Floating-point determinism across engines
+
+Parity is a claim about **bits**, not about closeness: the corpus differential
+compares printed floats raw, so a one-ulp difference fails the gate exactly
+like a wrong answer. Two things make that achievable.
+
+- **Eshkol's own codegen never contracts.** `llvm_codegen.cpp` emits `fmul` /
+  `fadd` and sets no fast-math flags and no `llvm.fmuladd`, so an Eshkol-level
+  `(+ (* a b) c)` rounds twice on every target.
+- **The C runtime and the VM are compiled with `-ffp-contract=off`**, set
+  project-wide in `CMakeLists.txt` and repeated on the Emscripten command line
+  in `scripts/run_wasm_differential.sh`. Contraction of `a * b + c` into a
+  single, singly-rounded multiply-add is a *per-target* liberty: AArch64 and
+  x86-64-with-FMA take it, and WebAssembly cannot, because the instruction set
+  has no scalar f64 FMA. Left at the compiler default (`-ffp-contract=on`) one
+  and the same C kernel therefore produces different bits on different
+  engines, with nothing in the source to show it.
+
+That is not hypothetical. The forward-mode dual quotient rule shared by
+`eshkol_tensor_layer_norm_dual` (`lib/core/runtime_tensor_math.cpp`) and
+`vm_tensor_dual_div` (`lib/backend/vm_tensor_ops.c`) is written
+`a.tangent * inv - a.primal * b.tangent * inv2`. Contracted, the layer-norm
+tangent in `tests/vm_parity/corpus/551_tensor_transformer_dual.esk` is
+`0.20413179969792875`; evaluated as written it is `0.20413179969792872`. The
+native builds fused it, the WASM build could not, and the execute-and-diff lane
+failed on the last digit of one printed double while every other byte matched.
+
+A kernel that genuinely wants a fused, singly-rounded product must call `fma()`
+explicitly: `fma()` is correctly rounded on both libm implementations in play,
+so it is identical on every engine, whereas *contraction* is whatever the
+back end happens to be able to do. The rule is therefore "evaluate binary64
+arithmetic as written, and spell fusion out when you want it" — never a
+tolerance in the differential, and never rounding the printed digits.
+
 See also [TESTING.md](TESTING.md) for the full adversarial-testing overview.
 Reclassified cases are listed in [tests/vm_parity/resolved/README.md](../tests/vm_parity/resolved/README.md).

--- a/lib/backend/vm_tensor_ops.c
+++ b/lib/backend/vm_tensor_ops.c
@@ -878,6 +878,12 @@ static VmDual vm_tensor_dual_sub(VmDual a, VmDual b) {
     return (VmDual){a.primal - b.primal, a.tangent - b.tangent};
 }
 
+/* These mirror lib/core/runtime_tensor_math.cpp's jet arithmetic operation for
+ * operation, and — like it — rely on the project-wide -ffp-contract=off set in
+ * CMakeLists.txt.  The VM is compiled twice, natively and to WebAssembly, and
+ * only the native target has a fused multiply-add instruction; contracting
+ * `a*b + c` here would make the same VM source round differently on the two
+ * engines (see docs/VM_PARITY.md). */
 static VmDual vm_tensor_dual_mul(VmDual a, VmDual b) {
     return (VmDual){a.primal * b.primal,
                     a.tangent * b.primal + a.primal * b.tangent};

--- a/lib/core/runtime_tensor_math.cpp
+++ b/lib/core/runtime_tensor_math.cpp
@@ -74,6 +74,14 @@ static tensor_dual_jet jet_sub(const tensor_dual_jet& a,
     return out;
 }
 
+/* The product and quotient rules below are written as plain multiplies and
+ * adds, and the build compiles them that way: CMakeLists.txt sets
+ * -ffp-contract=off for the whole project because these kernels feed the
+ * cross-engine parity contract (docs/VM_PARITY.md).  Letting a compiler fuse
+ * `a*b + c` here rounds once on AArch64/x86-64-with-FMA and twice on
+ * WebAssembly, which has no scalar f64 FMA instruction — a one-ulp
+ * native-vs-WASM divergence in the same source.  If a future kernel wants a
+ * fused product, it must say so with an explicit fma() call. */
 static tensor_dual_jet jet_mul(const tensor_dual_jet& a,
                                const tensor_dual_jet& b) {
     tensor_dual_jet out{};

--- a/scripts/run_wasm_differential.sh
+++ b/scripts/run_wasm_differential.sh
@@ -256,7 +256,14 @@ if [ "$need_build" -eq 1 ]; then
     # (e.g. tests/vm_parity/corpus/31_tensor_matmul.esk traps "out of bounds"
     # at 64KB, passes at 8MB) — a build limit, NOT a codegen divergence, so we
     # provision to parity rather than mask it in normalization.
-    if ! emcc -O2 -s WASM=1 -s MODULARIZE=1 -s EXPORT_NAME='EshkolVMDiff' \
+    # -ffp-contract=off mirrors the project-wide setting in CMakeLists.txt: the
+    # native build must not fuse `a*b + c` into a singly-rounded multiply-add
+    # that WebAssembly (which has no scalar f64 FMA instruction) cannot
+    # reproduce, and this side states the same rule explicitly instead of
+    # relying on the wasm backend's inability to contract.  Without it the
+    # forward-dual quotient rule in the layer-norm AD kernel diverged by one
+    # ulp from native (551_tensor_transformer_dual.esk).
+    if ! emcc -O2 -ffp-contract=off -s WASM=1 -s MODULARIZE=1 -s EXPORT_NAME='EshkolVMDiff' \
             -s ENVIRONMENT=node -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
             -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap","FS"]' \
             -s EXPORTED_FUNCTIONS='["_run_program","_eshkol_tensor_shape_total","_fflush","_malloc","_free"]' \


### PR DESCRIPTION
## What failed

`scripts/run_wasm_differential.sh --quick` on `integration/astra-v135` (head `51defcf7`):

```
FAILED tests/vm_parity/corpus/551_tensor_transformer_dual.esk::wasm-vs-native
  native=<...0.20413179969792875...>  wasm=<...0.20413179969792872...>
```

One printed double, one ulp, everything else byte-identical; the program prints `PASS` on both engines. Native output is stable across repeated runs — this is not nondeterminism.

## The exact operation

The forward-mode dual **quotient rule**, evaluated for `centered / stddev` inside layer-norm:

```c
tangent = a.tangent * inv - a.primal * b.tangent * inv2;
```

It is written identically in the two engines' kernels — `jet_div` in `lib/core/runtime_tensor_math.cpp` (reached from native codegen via `eshkol_tensor_layer_norm_dual`) and `vm_tensor_dual_div` in `lib/backend/vm_tensor_ops.c` (the VM, which is what Emscripten compiles).

## The mechanism

Fused multiply-add contraction. At the compiler default (`-ffp-contract=on`) clang is free to fuse `a*b + c` into one instruction with a single rounding. It does: `eshkol_tensor_layer_norm_dual` alone compiled to **five `fmadd` instructions** on AArch64 (47 across that translation unit). WebAssembly has no scalar f64 FMA instruction, so the emcc build cannot fuse and rounds twice. Same source, different bits.

Isolated outside the compiler, with the kernel's arithmetic transcribed to a standalone program:

| build | layer-norm tangent |
|---|---|
| `cc -O2` (contract on, the default) | `0.20413179969792875` |
| `cc -O2 -ffp-contract=off` | `0.20413179969792872` |

and narrowing by pragma showed the contraction that matters is in the **divide**, not the multiply.

Contraction is a *per-target* liberty, not a per-language one, so leaving it at the default makes the parity promise depend on which instructions a back end happens to have. It also means the same native binary could disagree with itself across architectures.

## The fix

- `CMakeLists.txt` — compile every translation unit with `-ffp-contract=off` (probed with `check_c_compiler_flag`; `/clang:`-escaped for the clang-cl Windows front end, with a loud `message(WARNING)` if some future compiler accepts neither spelling).
- `scripts/run_wasm_differential.sh` — pass the same flag to `emcc`, so the WASM side states the rule instead of merely being unable to break it.
- `lib/core/runtime_tensor_math.cpp`, `lib/backend/vm_tensor_ops.c` — comments at the jet/dual arithmetic recording why these kernels must not be contracted.
- `docs/VM_PARITY.md` — a new "Floating-point determinism across engines" section making this part of the stated parity contract: evaluate binary64 as written, and spell fusion out with an explicit `fma()` when you want it. Not a tolerance in the differential, and not rounding the printed digits.

Eshkol's own codegen was already clean: `llvm_codegen.cpp` sets no fast-math flags and emits no `llvm.fmuladd`, so only the C runtime and the VM needed this.

## Before / after

`build/eshkol-run -r tests/vm_parity/corpus/551_tensor_transformer_dual.esk`, native, one line changes:

```
-0.20413179969792875
+0.20413179969792872
```

Everything else in that program's output, and in every other corpus program, is unchanged.

## Verification (all local, macOS arm64, Release + tests)

| gate | result |
|---|---|
| `run_wasm_differential.sh --quick` | **120 passed, 0 failed**, 3 excluded (was 119/1) |
| `run_wasm_differential.sh --full` | **162 passed, 0 failed**, 16 excluded |
| `run_vm_parity.sh` | **284 passed, 0 failed**, 0 infra |
| `ctest -R "wasm\|vm_parity\|tensor\|dual\|ad_"` | **70/70 passed** |
| `scripts/run_all_tests.sh` | **46/46 suites, 895/895 tests, 100%** |
| `check_wasm_imports.py --build-dir build` | OK — 12 surfaces, 122 env imports, all provided |
| object check | 47 → **0** FMA instructions in `runtime_tensor_math.cpp.o` |

## Notes for review

- No xfail and no manifest row: `tests/wasm_diff/EXCLUSIONS.tsv` is untouched.
- The CI fetch-content cache key hashes `CMakeLists.txt`, so the first run on this branch re-populates it.
- Disabling contraction can cost a little throughput in the float kernels; BLAS-backed paths are unaffected (external library), and the benchmark suite passes.
