### PR TITLE
Builtin calls that omit a documented optional argument compile on both engines

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -6,6 +6,36 @@
 
 ## Resolved in v1.3.5-evolve
 
+- **The bytecode VM accepts a call that omits a documented optional argument.**
+  `(substring "hello" 1)`, `(make-vector 3)`, `(make-string 3)`,
+  `(read-line)`, `(append lst)` and `(hash-ref table key)` all ran on native and
+  were refused by the VM with `Arity mismatch: … expects N arguments but got M`.
+  The cause was structural: the `arity` column of `BUILTINS[]` is the **opcode's
+  operand count**, not the caller's obligation, and the VM's under-arity check
+  fell back to it for every row that left `min_arity` unset — 739 rows out of
+  742. The minima are now DERIVED rather than typed
+  (`scripts/gen_builtin_min_arity.py`, from the fixed-arity macro the native
+  dispatch expands, the arity guard the lowering enforces, and the declarative
+  documented signature), `scripts/check_builtin_min_arity.py` re-derives them
+  and fails the build on drift, and the operands a caller legally omits are
+  supplied at the call site as an absent marker that each native op reads as
+  "apply the documented default". Nineteen builtins carry an omissible
+  argument; all nineteen are exercised at their minimum and maximum arity by
+  `tests/vm_parity/corpus/82_builtin_optional_argument_arity.esk`. Three of
+  them are the R7RS variadic FOLDS, whose minimum is zero and whose identity
+  the omitted operand supplies — `(append)` is the empty list (R7RS 6.4),
+  `(gcd)` is 0 and `(lcm)` is 1 (6.2.6), `(bytevector-append)` is the empty
+  bytevector. Those three are derived from the code native runs rather than
+  from prose: the core-module definition `(define (append . lists) (cond
+  ((null? lists) (quote ())) …))`, and the lowering's own `num_vars == 0`
+  case. They were the worse half of the defect, because a row declared
+  variadic makes no minimum claim, so the VM's compile-time check never fired
+  for it and `(gcd)` died at RUNTIME instead, where the closure wanted both
+  operands.
+  `hash-ref` had the column filled in already and still failed — at RUNTIME,
+  where the closure arity check wanted three operands — which is why the fact
+  and the operand-supply had to land together.
+
 - **A wrong-arity call to a builtin is refused with the same sentence on every
   engine.** Both the native LLVM backend and the bytecode VM already *refused*
   a call like `(ceiling)`; they just said so differently. The VM printed
@@ -346,21 +376,29 @@ block ordinary use.
 
 **Found during the v1.3.4-evolve correctness wave (new, honest knowns)**
 
-- **The bytecode VM refuses some legal short calls that native accepts.**
-  `(make-string 3)`, `(append)`, `(append lst)`, `(substring s 1)`,
-  `(string-pad-left s n)`, `(string-index-of s c)` and `(read-line)` compile and
-  run on native and are refused by the VM with
-  `Arity mismatch: … expects N arguments but got M`. The cause is structural:
-  the `arity` column of `BUILTINS[]` is the **opcode's operand count**, not the
-  caller's obligation, and the VM's under-arity check falls back to it whenever
-  a row leaves `min_arity` unset — which is nearly every row. The `min_arity`
-  column exists for exactly this (`hash-ref` uses it) but has only been filled
-  in where someone noticed. Giving the table a real caller-minimum column is
-  the fix and is tracked as a build item; until then the native engine
-  deliberately does **not** import the same rule (see
-  [VM_PARITY.md](VM_PARITY.md)), because doing so would spread the defect
-  rather than close it. The P8 axis-3 sweep does not see this class: it only
-  ever shortens a call by one argument from the table's own number.
+- **Four value divergences the optional-argument probe uncovered, none of them
+  about arity.** Probing every optional-argument builtin at its minimum and
+  maximum argument count put the two engines side by side over calls nobody had
+  compared before, and four answers differ for reasons that reproduce at FULL
+  arity too: `(hash-ref table key default)` answers the default's raw integer
+  bits on the VM (`vm_ht_ref` stores `void*`, so a symbol comes back as a
+  number) where native answers the value; `(write-string s)` answers `0` on
+  native and the unspecified value on the VM; `(make-tensor shape)` builds a
+  rank-1 tensor on native where the VM builds the requested shape; and the
+  `(bytevector …)` constructor and `current-input-port` / `current-output-port`
+  are not callable on the VM at all. Each is its own build item.
+
+- **Some documented optional parameters are not implemented on either engine.**
+  `scripts/gen_builtin_min_arity.py` reports 33 builtins whose documented
+  signature describes an optional parameter that no lowering provides —
+  `(string-pad-left s width [char])` is documented with an optional pad
+  character, and `stringPadLeft` is a `THREE_ARG_BUILTIN`, so the two-argument
+  call returns null on native rather than padding with a space. The same shape
+  covers `(fg-infer! graph)`, `(make-workspace)`, `(allow-sleep)` and the AD
+  tape wrappers. The documentation is the specification here and the engines
+  are behind it, so the table records the arity the engines actually implement
+  and the generator names every page that is ahead of them; run it to see the
+  list. Building each one up to its documented signature is the remaining work.
 
 - **The two forward AD carriers now compose (fixed, ESH-0402).** Eshkol carries
   forward-mode derivatives in two representations — the 8-jet (`derivative`,

--- a/docs/VM_PARITY.md
+++ b/docs/VM_PARITY.md
@@ -55,16 +55,46 @@ to miss.
   That scope is a subset of the table on purpose. `arity` in `BUILTINS[]` is
   the OPCODE'S OPERAND COUNT, not the caller's obligation, and the VM applies
   it only where the call actually reaches the raw op: a name the VM compiler
-  special-cases (`make-vector`, `round`, `string->utf8`) or that the Scheme
-  prelude rebinds (`append`) never does. Applying the row to every name on
-  native would refuse `(make-vector 3)`, `(substring s 1)` and `(append)` —
-  legal calls the VM accepts — i.e. it would manufacture divergence. Widening
-  the scope requires giving the table a real caller-minimum column first; that
-  is a tracked build item, not a line to delete. The same gap is why the VM
-  currently refuses `(make-string 3)`, `(append)`, `(substring s 1)`,
-  `(string-pad-left s n)` and `(read-line)` while native accepts them — a
-  pre-existing divergence in the opposite direction, unaffected by the arity
-  probes because they only ever shorten a call by one argument.
+  special-cases (`round`, `string->utf8`) never does.
+- **A DOCUMENTED OPTIONAL ARGUMENT IS A LEGAL CALL ON BOTH ENGINES.** The
+  caller-minimum column the note above called for now exists, and it is
+  derived rather than typed: `scripts/gen_builtin_min_arity.py` reads the
+  fixed-arity macro the native dispatch expands
+  (`THREE_ARG_BUILTIN(stringPadLeft, …)` is an exact arity, stated by the code
+  that runs), the arity guard the lowering enforces (`substring requires 2 or 3
+  arguments: (substring string start [end])`), and the declarative documented
+  signature, in that order of authority, and writes the answer into
+  `min_arity` for all 742 rows. `scripts/check_builtin_min_arity.py` imports
+  that same module and re-derives, so editing a guard or a signature without
+  regenerating the table fails the build rather than opening a new divergence.
+
+  Nineteen rows carry an argument a caller may omit. For those the VM used to
+  refuse `(substring s 1)`, `(make-vector 3)`, `(make-string 3)`,
+  `(read-line)`, `(append)`, `(append lst)`, `(bytevector-append)` and
+  `(hash-ref table key)` — all legal, all accepted by native. Three of them are
+  the R7RS variadic FOLDS, and they are derived from the code native runs
+  rather than from prose: `append` from the core-module definition native
+  compiles (`(define (append . lists) (cond ((null? lists) '()) …))`),
+  `bytevector-append` and `gcd`/`lcm` from their lowering's own `num_vars == 0`
+  case. A row DECLARED variadic was the worse half of the defect: it makes no
+  minimum claim, so the compile-time check never fired for it, and `(gcd)` got
+  all the way to the closure call and died there wanting both operands. REFUSING WAS ONLY HALF OF IT: the VM's builtin body
+  loads a fixed number of operands and its runtime closure check wants exactly
+  that many, so `hash-ref`, whose `min_arity` had been filled in by hand, got
+  past the compiler and then died at runtime with
+  `arity mismatch: expected 3 arguments, got 2`. The call site therefore
+  supplies the omitted operands as `ESHKOL_ABSENT_ARG` — the VM's unspecified
+  value, which no source expression evaluates to — and the native op reads that
+  marker and applies the DOCUMENTED DEFAULT: `substring`'s missing `end` is the
+  string's length, `make-vector`'s missing fill is `0`, `read-line`'s missing
+  port is the current input. Lowering a row's minimum without teaching its op
+  that default would turn a refused call into a wrong answer, so the two always
+  land in the same change.
+  `tests/vm_parity/corpus/82_builtin_optional_argument_arity.esk` calls every
+  one of the nineteen at its minimum and at its maximum arity;
+  `tests/diagnostics/arity_below_documented_minimum` pins the refusal BELOW the
+  minimum to the canonical sentence, quoting the minimum (`substring expects 2
+  arguments`) rather than the opcode's three operands, on both engines.
 - **Canonical gap evidence (PR-05).** Every `gap` row in `PARITY.tsv` has a
   matching row in `tests/vm_parity/GAP_DISPOSITIONS.tsv`. The sidecar records
   an explicit disposition, a live `found/` reproducer when one exists, or the

--- a/lib/backend/eshkol_vm.c
+++ b/lib/backend/eshkol_vm.c
@@ -253,6 +253,7 @@ static int g_n_repatch = 0;
  * vm_compiler.c's generic call-compilation path (textually included next)
  * needs to consult it — see the definition after BUILTINS[] for why. */
 static int vm_builtin_arity_at_index(int local_index, const char* name);
+static int vm_builtin_operands_at_index(int local_index, const char* name);
 
 /* Bytecode compiler */
 #include "vm_compiler.c"
@@ -361,22 +362,42 @@ static int vm_load_prelude_cache(FuncChunk* chunk) {
  * longer sibling declares the extra slot here and lets the unsupplied local
  * default, so `arity` over-states its real minimum.
  *
- * `min_arity` is that real minimum, in three states, so that an entry which
+ * `min_arity` is that real minimum, in four states, so that an entry which
  * says nothing keeps costing nothing:
  *
- *   0   unset — the minimum IS `arity`. Almost every row leaves it implicitly
- *       zero, which is what a three-field initialiser produces.
- *   > 0 the real minimum, for a builtin sharing a longer sibling's opcode:
- *       `hash-ref` loads three operands but two is the documented call.
- *   < 0 VARIADIC in the native lowering — there is no minimum to enforce and
- *       the under-arity check does not apply. `gcd`/`lcm` are the case: their
- *       llvm_codegen handlers (codegenGCD/codegenLCM) return the R7RS identity
- *       for a zero-argument call and then loop over `num_vars`, so native
- *       accepts every count and the VM must not refuse one.
+ *   0   ESHKOL_BUILTIN_MIN_IS_ARITY — unset; the minimum IS `arity`. Most
+ *       rows leave it implicitly zero, which is what a three-field
+ *       initialiser produces.
+ *   > 0 the real minimum, for a builtin with a DOCUMENTED OPTIONAL parameter:
+ *       `substring` loads three operands but `(substring s 1)` is the
+ *       documented two-argument call.
+ *   -1  ESHKOL_BUILTIN_MIN_VARIADIC — variadic in the native lowering. There
+ *       is no minimum to enforce and the under-arity check does not apply.
+ *       `gcd`/`lcm` are the case: their llvm_codegen handlers
+ *       (codegenGCD/codegenLCM) return the R7RS identity for a zero-argument
+ *       call and then loop over `num_vars`, so native accepts every count and
+ *       the VM must not refuse one.
+ *   -2  ESHKOL_BUILTIN_MIN_ZERO — the documented minimum is ZERO: every
+ *       parameter is optional. `(read-line)`, `(read-char)` and
+ *       `(prevent-sleep)` are legal calls to rows whose opcode still loads an
+ *       operand. This needs a marker of its own because 0 is already spoken
+ *       for by "unset", and a row that cannot SAY zero is a row whose real
+ *       minimum is unsayable — which is how `(read-line)` came to be refused
+ *       by the VM and accepted by native.
  *
- * Keep this in agreement with tests/coverage/language_surface.json —
- * scripts/check_builtin_min_arity.py fails the build if the two drift. Note
- * the surface manifest is GENERATED from this table, so a row shape that
+ * A row whose minimum is BELOW its arity is calling for the missing operands
+ * to be supplied: emit_call() pushes ESHKOL_ABSENT_ARG (a VAL_VOID) for each
+ * one, and the native op reads that marker and applies the documented default
+ * — see vm_native_absent() in lib/backend/vm_native.c. Lowering a row's
+ * minimum WITHOUT teaching its op that default would turn a refused call into
+ * a wrong answer, so the two always land together.
+ *
+ * These numbers are GENERATED, not typed: scripts/gen_builtin_min_arity.py
+ * derives every one of them from the arity guard the native lowering already
+ * enforces and from the declarative documented signature, and
+ * scripts/check_builtin_min_arity.py re-derives them and fails the build when
+ * the table has drifted away from either. Note the surface manifest is also
+ * generated from this table, so a row shape that
  * scripts/gen_language_surface.py cannot parse deletes the builtin from the
  * manifest in silence; its pattern tracks BuiltinDef for that reason.
  *
@@ -397,6 +418,9 @@ static int vm_load_prelude_cache(FuncChunk* chunk) {
  * <public-name> on the native surface itself and only then treats this row as
  * covered.  Naming a target the native engine does not have leaves the
  * disagreement standing. */
+#define ESHKOL_BUILTIN_MIN_IS_ARITY  0
+#define ESHKOL_BUILTIN_MIN_VARIADIC (-1)
+#define ESHKOL_BUILTIN_MIN_ZERO     (-2)
 typedef struct { const char* name; int native_id; int arity; int min_arity; int variadic; } BuiltinDef;
 
 static const BuiltinDef BUILTINS[] = {
@@ -456,7 +480,7 @@ static const BuiltinDef BUILTINS[] = {
     /* Equality — IDs 133-134 */
     {"eq?", 133, 2}, {"eqv?", 133, 2}, {"equal?", 134, 2},
     /* List operations — IDs 135-141 */
-    {"append", 135, 2}, {"reverse", 136, 1},
+    {"append", 135, 2, -2}, {"reverse", 136, 1},
     {"member", 137, 2}, {"assoc", 138, 2}, {"memq", 139, 2},
     {"list->vector", 227, 1}, {"vector->list", 140, 1}, {"iota", 141, 1},
     /* Arithmetic as first-class (2-arg) — IDs 142-145 */
@@ -482,18 +506,18 @@ static const BuiltinDef BUILTINS[] = {
     {"exact->inexact", 213, 1}, {"inexact->exact", 214, 1},
     {"string->number", 215, 1},
     {"char->integer", 216, 1}, {"integer->char", 217, 1},
-    {"make-vector", 218, 2}, {"vector-ref", 219, 2}, {"vref", 219, 2}, {"vector-set!", 220, 3},
+    {"make-vector", 218, 2, 1}, {"vector-ref", 219, 2}, {"vref", 219, 2}, {"vector-set!", 220, 3},
     {"vector-length", 221, 1},
     {"string->list", 222, 1}, {"list->string", 223, 1},
     /* Variadic in native: codegenGCD/codegenLCM answer a zero-argument call
      * with the R7RS identity (0 and 1) and then fold over `num_vars`, so
      * `(gcd 3)` is legal and must not be refused here. The opcode still
      * takes two operands, which is why the row cannot say so with `arity`. */
-    {"gcd", 224, 2, -1}, {"lcm", 225, 2, -1}, {"make-string", 226, 2},
+    {"gcd", 224, 2, -1}, {"lcm", 225, 2, -1}, {"make-string", 226, 2, 1},
     /* String operations — compiler opcodes cover inline use;
      * these entries make them first-class closures for higher-order use */
     {"string-length", 550, 1}, {"string-ref", 551, 2},
-    {"substring", 553, 3},
+    {"substring", 553, 3, 2},
     {"_string-append-2", 554, 2},  /* 2-arg; prelude defines variadic string-append */
     {"string-upcase", 557, 1}, {"string-downcase", 558, 1},
     {"string-contains", 555, 2},
@@ -571,7 +595,7 @@ static const BuiltinDef BUILTINS[] = {
     /* ═══════════════════════════════════════════════════════════════
      * Tensors — IDs 410-470
      * ═══════════════════════════════════════════════════════════════ */
-    {"make-tensor", 410, 2},
+    {"make-tensor", 410, 2, 1},
     /* `tensor` is NOT an alias of make-tensor: it is the variadic constructor
      * compiled by vm_compiler.c's (tensor ...) special form via native 473.
      * This first-class entry is the closure form, reached only when `tensor` is
@@ -709,8 +733,8 @@ static const BuiltinDef BUILTINS[] = {
      * I/O — IDs 580-602
      * ═══════════════════════════════════════════════════════════════ */
     {"open-input-file", 580, 1}, {"open-output-file", 581, 1},
-    {"close-port", 582, 1}, {"read-char", 583, 1}, {"read-line", 585, 1},
-    {"write-char", 586, 1}, {"write-string", 587, 2},
+    {"close-port", 582, 1}, {"read-char", 583, 1, -2}, {"read-line", 585, 1, -2},
+    {"write-char", 586, 1}, {"write-string", 587, 2, 1},
     {"_read0", 588, 0}, {"_read1", 619, 1},
     {"eof-object?", 592, 1},
     {"open-input-string", 596, 1}, {"open-output-string", 597, 0},
@@ -808,8 +832,8 @@ static const BuiltinDef BUILTINS[] = {
     {"http-set-proxy", 2065, 1}, {"http-set-tls-client-cert", 2066, 3},
     {"display-error", 2067, 1},
     {"open-binary-input-file", 2068, 1}, {"open-binary-output-file", 2069, 1},
-    {"read-u8", 2070, 1}, {"write-u8", 2071, 2},
-    {"read-bytevector", 2072, 2}, {"write-bytevector", 2073, 2},
+    {"read-u8", 2070, 1, -2}, {"write-u8", 2071, 2, 1},
+    {"read-bytevector", 2072, 2, 1}, {"write-bytevector", 2073, 2, 1},
     {"string-ends-with?", 1956, 2}, {"string-index-of", 1957, 3},
     {"string-pad-left", 1958, 3}, {"string-pad-right", 1959, 3},
     /* Parallel primitives — IDs 620-628 */
@@ -819,9 +843,9 @@ static const BuiltinDef BUILTINS[] = {
     {"future-ready?", 627, 1},
     {"thread-pool-info", 628, 0}, {"thread-pool-size", 628, 0},
     /* Bytevectors — IDs 680-689 */
-    {"make-bytevector", 680, 2}, {"bytevector-length", 681, 1},
+    {"make-bytevector", 680, 2, 1}, {"bytevector-length", 681, 1},
     {"bytevector-u8-ref", 682, 2}, {"bytevector-u8-set!", 683, 3},
-    {"bytevector-append", 684, 2}, {"bytevector-copy!", 685, 3},
+    {"bytevector-append", 684, 2, -2}, {"bytevector-copy!", 685, 3},
     {"bytevector?", 686, 1}, {"bytevector-copy", 687, 1},
     {"utf8->string", 688, 1}, {"string->utf8", 689, 1},
     /* ═══════════════════════════════════════════════════════════════
@@ -926,7 +950,7 @@ static const BuiltinDef BUILTINS[] = {
     {"file-mtime", 1752, 1}, {"file-atime", 1753, 1},
     {"file-lock", 1754, 1}, {"file-unlock", 1755, 1},
     {"glob-expand", 1756, 1}, {"glob-match", 1757, 2},
-    {"file-mmap", 1758, 3}, {"file-munmap", 1759, 1},
+    {"file-mmap", 1758, 3, 1}, {"file-munmap", 1759, 1},
     {"make-temp-file", 1760, 3}, {"make-temp-dir", 1761, 2},
     /* ═══════════════════════════════════════════════════════════════
      * Shell Utilities — IDs 1770-1779
@@ -935,7 +959,7 @@ static const BuiltinDef BUILTINS[] = {
     /* ═══════════════════════════════════════════════════════════════
      * Process Management — IDs 1780-1799
      * ═══════════════════════════════════════════════════════════════ */
-    {"process-spawn", 1780, 3}, {"process-wait", 1781, 1},
+    {"process-spawn", 1780, 3, 2}, {"process-wait", 1781, 1},
     {"process-spawn-with-env", 1780, 3},
     {"process-spawn-argv-env", 1780, 3},
     {"process-spawn-argv-options", 1803, 2},
@@ -1009,7 +1033,9 @@ static const BuiltinDef BUILTINS[] = {
  * the same row. */
 static int vm_builtin_row_min_arity(const BuiltinDef* def) {
     int declared_min = def->min_arity;
-    if (declared_min < 0) return -1;   /* variadic in native — no claim to make */
+    if (declared_min == ESHKOL_BUILTIN_MIN_VARIADIC) return -1;  /* no claim to make */
+    if (declared_min == ESHKOL_BUILTIN_MIN_ZERO) return 0;       /* all optional */
+    if (declared_min < 0) return -1;   /* any other negative: no claim */
     return declared_min ? declared_min : def->arity;
 }
 
@@ -1053,6 +1079,26 @@ static int vm_builtin_arity_at_index(int local_index, const char* name) {
      * reject `(hash-ref table key)`, which is the documented two-argument
      * form. */
     return vm_builtin_row_min_arity(&BUILTINS[local_index]);
+}
+
+/**
+ * @brief How many operands the OPCODE bound at top-level local @p local_index
+ *        under @p name loads, or -1 when that local is not a preamble binding
+ *        of that builtin.
+ *
+ * The companion of vm_builtin_arity_at_index(), which answers the CALLER's
+ * minimum. The two differ exactly when the row documents an optional
+ * parameter, and the gap between them is the number of operands the call site
+ * has to supply on the caller's behalf: emit_builtin_preamble() compiles the
+ * body as `arity` unconditional OP_GET_LOCAL loads, so a shorter call must
+ * arrive with the missing slots already filled by ESHKOL_ABSENT_ARG rather
+ * than reading whatever the stack happened to hold.
+ */
+static int vm_builtin_operands_at_index(int local_index, const char* name) {
+    int n_builtins = vm_builtin_count();
+    if (local_index < 0 || local_index >= n_builtins || !name || !*name) return -1;
+    if (strcmp(BUILTINS[local_index].name, name) != 0) return -1;
+    return BUILTINS[local_index].arity;
 }
 
 /* THE SHARED ARITY FACT — see inc/eshkol/core/arity_contract.h.

--- a/lib/backend/string_io_codegen.cpp
+++ b/lib/backend/string_io_codegen.cpp
@@ -540,8 +540,21 @@ llvm::Value* StringIOCodegen::substring(const eshkol_operations_t* op) {
     // 2-arg form warned and returned null, which surfaced as () and
     // silently corrupted callers (Noesis ESH-0180).
     const uint32_t nargs = op->call_op.num_vars;
-    if (nargs != 2 && nargs != 3) {
-        eshkol_error("substring requires 2 or 3 arguments: (substring string start [end])");
+    if (nargs < 2) {
+        // UNDER the documented minimum: the canonical sentence, rendered from
+        // the shared formatter so it is byte-identical to the one the bytecode
+        // VM's compiler prints for the same call — and quoting the MINIMUM (2),
+        // not the opcode's three operands. This is the wording the P8 axis-3
+        // ratchet compares; see inc/eshkol/core/arity_contract.h.
+        eshkol_arity_error_named("substring", 2, (long long)nargs);
+        return nullptr;
+    }
+    if (nargs > 3) {
+        // Over the maximum. The guard has something more specific to say than
+        // the canonical sentence, so it says it and eshkol_arity_error_current()
+        // prepends the class marker centrally.
+        eshkol_arity_error_current(
+            "substring requires 2 or 3 arguments: (substring string start [end])");
         return nullptr;
     }
 

--- a/lib/backend/vm_compiler.c
+++ b/lib/backend/vm_compiler.c
@@ -6053,6 +6053,7 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
      * from allocating slots that conflict with operand stack values. */
     if (head->type == N_SYMBOL || head->type == N_LIST) {
         int argc = node->n_children - 1;
+        int pad_absent_args = 0;
         /* P8 axis-3 parity (see vm_builtin_arity_at_index): a call to a raw
          * BUILTINS[] op with the wrong argument count used to compile clean
          * and read an uninitialised local at runtime — native has refused it
@@ -6064,6 +6065,8 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
          * g_vm_user_locals_base > 0 so the prelude, which calls these names
          * through its own wrappers while it is still being compiled, is not
          * under test here; the P8 divergence lives in user source. */
+        int builtin_operands = -1;   /* the opcode's operand count, when the head
+                                      * resolves to a raw BUILTINS[] binding */
         if (head->type == N_SYMBOL && g_vm_user_locals_base > 0) {
             int decl_arity = -1;
             for (FuncChunk* p = c; p; p = p->enclosing) {
@@ -6072,8 +6075,10 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
                     if (strcmp(p->locals[i].name, head->symbol) == 0) { li = i; break; }
                 }
                 if (li < 0) continue;
-                if (p->enclosing == NULL)
+                if (p->enclosing == NULL) {
                     decl_arity = vm_builtin_arity_at_index(li, head->symbol);
+                    builtin_operands = vm_builtin_operands_at_index(li, head->symbol);
+                }
                 break;  /* nearest binding wins; anything else shadows the raw op */
             }
             /* Only TOO FEW arguments are refused. The preamble body loads
@@ -6097,6 +6102,24 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
                                              head->symbol, decl_arity, argc);
                 vm_compile_error(arity_msg, NULL);
             }
+            /* At or above the minimum but below the opcode's operand count —
+             * or ANY count below it, for a row that declares itself variadic
+             * and so states no minimum at all (`gcd`, `lcm`, whose native
+             * lowering answers a zero-argument call with the R7RS identity).
+             * A variadic row is the WORSE case, not an exempt one: the refusal
+             * above never fires for it, so `(gcd)` used to compile clean and
+             * die at the closure call wanting both operands.
+             * Either way the caller has legally OMITTED an argument,
+             * and the missing operands are this call site's to supply. Nothing
+             * else can: emit_builtin_preamble() compiles the body as `arity`
+             * unconditional OP_GET_LOCAL loads and the closure's runtime arity
+             * check (vm_validate_closure_arity) wants exactly that many, so a
+             * short call either arrives complete or reads a slot no caller
+             * wrote. Padding here keeps BOTH checks exact and leaves the
+             * DEFAULT to the one place that knows it — the native op, which
+             * recognises ESHKOL_ABSENT_ARG (vm_native_absent()). */
+            if (builtin_operands > argc && (decl_arity < 0 || argc >= decl_arity))
+                pad_absent_args = builtin_operands - argc;
         }
         int saved_locals = c->n_locals;
         compile_expr(c, head, 0);  /* push function */
@@ -6104,6 +6127,16 @@ static void compile_expr_impl(FuncChunk* c, Node* node, int tail) {
         for (int i = 1; i < node->n_children; i++) {
             compile_expr(c, node->children[i], 0);
             add_local(c, "__call_arg__");
+        }
+        for (int i = 0; i < pad_absent_args; i++) {
+            /* ESHKOL_ABSENT_ARG — the marker the native op reads as "this
+             * documented-optional argument was not supplied". OP_VOID is the
+             * VM's unspecified value and is not a value any expression in a
+             * source program evaluates to, so an op cannot mistake a real
+             * argument for an absent one. */
+            chunk_emit(c, OP_VOID, 0);
+            add_local(c, "__call_arg__");
+            argc++;
         }
         if (head->type == N_SYMBOL && vm_language_coverage_compilation_enabled()) {
             chunk_emit(c, OP_LANGUAGE_COVERAGE_CALL,

--- a/lib/backend/vm_native.c
+++ b/lib/backend/vm_native.c
@@ -8285,6 +8285,30 @@ static int vm_math_promote_negative(VM* vm, Value a, int is_sqrt) {
     return 1;
 }
 
+/**
+ * @brief Was this operand OMITTED by the caller?
+ *
+ * ESHKOL_ABSENT_ARG. A builtin whose BUILTINS[] row declares a caller minimum
+ * below its opcode's operand count has DOCUMENTED OPTIONAL parameters —
+ * `(substring s 1)`, `(read-line)`, `(make-vector 3)` are legal calls that the
+ * native engine has always accepted. The VM's builtin bodies load a fixed
+ * number of operands, so the call site fills the omitted slots with the VM's
+ * unspecified value (OP_VOID) rather than leaving them unwritten, and the op
+ * below applies the DOCUMENTED DEFAULT for whichever of its parameters came
+ * back absent.
+ *
+ * A source expression never evaluates to VAL_VOID, so an op cannot mistake a
+ * real argument for an omitted one. The default belongs here and nowhere else:
+ * `substring`'s missing `end` is the string's length, `make-vector`'s missing
+ * fill is 0, `read-line`'s missing port is the current input — facts only the
+ * operation knows, which is why lowering a row's minimum without teaching its
+ * op the default would turn a refused call into a wrong answer.
+ *
+ * @see BuiltinDef and vm_builtin_row_min_arity() in lib/backend/eshkol_vm.c
+ * @see scripts/gen_builtin_min_arity.py, which derives the minima
+ */
+static inline int vm_native_absent(Value v) { return v.type == VAL_VOID; }
+
 static void vm_dispatch_native(VM* vm, int fid) {
     vm_timers_poll_due(vm);
     if (vm->native_policy == ESHKOL_VM_NATIVE_POLICY_HOST_ONLY &&
@@ -11218,11 +11242,15 @@ static void vm_dispatch_native(VM* vm, int fid) {
         } else vm_push(vm, NIL_VAL);
         break;
     }
-    case 553: { /* substring(str, start, end) */
+    case 553: { /* substring(str, start [, end]) */
         Value end = vm_pop(vm), start = vm_pop(vm), s_val = vm_pop(vm);
         if (s_val.type == VAL_STRING && vm->heap.objects[s_val.as.ptr]->opaque.ptr) {
             VmString* s = (VmString*)vm->heap.objects[s_val.as.ptr]->opaque.ptr;
-            VmString* result = vm_string_substring(&vm->heap.regions, s, (int)as_number(start), (int)as_number(end));
+            /* `(substring s start)` — the documented two-argument call — runs
+             * to the end of the string, which is what the native lowering
+             * does for the same call (string_io_codegen.cpp). */
+            int end_index = vm_native_absent(end) ? s->char_len : (int)as_number(end);
+            VmString* result = vm_string_substring(&vm->heap.regions, s, (int)as_number(start), end_index);
             if (result) { VM_PUSH_HEAP_OPAQUE(vm, HEAP_STRING, VAL_STRING, result); }
             else vm_push(vm, NIL_VAL);
         } else vm_push(vm, NIL_VAL);
@@ -11456,11 +11484,15 @@ static void vm_dispatch_native(VM* vm, int fid) {
         vm_push(vm, (Value){.type = VAL_VOID});
         break;
     }
-    case 585: { /* read-line(port) */
+    case 585: { /* read-line([port]) */
         Value port_val = vm_pop(vm);
-        VmPort* port = vm_value_as_port(vm, port_val);
-        if (port_val.type != VAL_PORT || !port || !port->is_open ||
-            port->dir != VM_PORT_INPUT) {
+        /* `(read-line)` reads the current input port, as R7RS specifies and as
+         * the native lowering does; only a port argument that is PRESENT and
+         * wrong is an error. */
+        VmPort* port = vm_native_absent(port_val) ? vm_port_current_input()
+                                                  : vm_value_as_port(vm, port_val);
+        if ((!vm_native_absent(port_val) && port_val.type != VAL_PORT) ||
+            !port || !port->is_open || port->dir != VM_PORT_INPUT) {
             vm_raise_error_msg(vm, "read-line: expected an open input port");
             break;
         }
@@ -11468,7 +11500,9 @@ static void vm_dispatch_native(VM* vm, int fid) {
         if (line) {
             VM_PUSH_HEAP_OPAQUE(vm, HEAP_STRING, VAL_STRING, line);
         } else {
-            vm_push(vm, NIL_VAL);
+            /* End of input is the EOF object, the same answer native gives
+             * and the one `(eof-object? (read-line))` is written against. */
+            vm_push(vm, (Value){.type = VAL_EOF});
         }
         break;
     }
@@ -13507,23 +13541,31 @@ static void vm_dispatch_native(VM* vm, int fid) {
         vm_push(vm, BOOL_VAL(0));
         break;
     }
-    case 2070: { /* read-u8(port) → byte or eof */
+    case 2070: { /* read-u8([port]) → byte or eof */
         Value port_val = vm_pop(vm);
-        VmPort* p = vm_value_as_port(vm, port_val);
+        VmPort* p = vm_native_absent(port_val) ? vm_port_current_input()
+                                               : vm_value_as_port(vm, port_val);
         int b = vm_port_read_u8(p);
-        vm_push(vm, b < 0 ? NIL_VAL : INT_VAL(b));
+        /* END OF INPUT IS THE EOF OBJECT, not the empty list. `read-char`
+         * (case 583) has always answered VAL_EOF, tests/io/binary_io_test.esk
+         * checks `(eof-object? (read-u8 in))`, and the native engine passes
+         * it; the VM answered `()`, so `eof-object?` said #f and a reader
+         * loop written against the documented contract never terminated. */
+        vm_push(vm, b < 0 ? (Value){.type = VAL_EOF} : INT_VAL(b));
         break;
     }
-    case 2071: { /* write-u8(byte, port) → void */
+    case 2071: { /* write-u8(byte [, port]) → void */
         Value port_val = vm_pop(vm), byte_val = vm_pop(vm);
-        VmPort* p = vm_value_as_port(vm, port_val);
+        VmPort* p = vm_native_absent(port_val) ? vm_port_current_output()
+                                               : vm_value_as_port(vm, port_val);
         vm_port_write_u8(p, (int)as_number(byte_val));
         vm_push(vm, NIL_VAL);
         break;
     }
-    case 2072: { /* read-bytevector(k, port) → bytevector or eof */
+    case 2072: { /* read-bytevector(k [, port]) → bytevector or eof */
         Value port_val = vm_pop(vm), k_val = vm_pop(vm);
-        VmPort* p = vm_value_as_port(vm, port_val);
+        VmPort* p = vm_native_absent(port_val) ? vm_port_current_input()
+                                               : vm_value_as_port(vm, port_val);
         int k = (int)as_number(k_val);
         if (!p || k < 0) { vm_push(vm, NIL_VAL); break; }
         VmBytevector* bv = vm_bv_make(&vm->heap.regions, k, 0);
@@ -13534,14 +13576,17 @@ static void vm_dispatch_native(VM* vm, int fid) {
             if (b < 0) break;
             bv->data[n] = (uint8_t)b;
         }
-        if (n == 0 && k > 0) { vm_push(vm, NIL_VAL); break; }
+        /* R7RS: the eof object only when NO bytes could be read; a short
+         * read answers the shorter bytevector. */
+        if (n == 0 && k > 0) { vm_push(vm, (Value){.type = VAL_EOF}); break; }
         bv->len = n;
         VM_PUSH_HEAP_OPAQUE(vm, HEAP_BYTEVECTOR, VAL_BYTEVECTOR, bv);
         break;
     }
-    case 2073: { /* write-bytevector(bv, port) → void */
+    case 2073: { /* write-bytevector(bv [, port]) → void */
         Value port_val = vm_pop(vm), bv_val = vm_pop(vm);
-        VmPort* p = vm_value_as_port(vm, port_val);
+        VmPort* p = vm_native_absent(port_val) ? vm_port_current_output()
+                                               : vm_value_as_port(vm, port_val);
         VmBytevector* bv = vm_value_as_bytevector(vm, bv_val);
         if (p && bv) vm_port_write_bytevector(p, (const char*)bv->data, bv->len);
         vm_push(vm, NIL_VAL);
@@ -14262,8 +14307,22 @@ static void vm_dispatch_native(VM* vm, int fid) {
         vm_push(vm, NIL_VAL);
         break;
     }
-    case 684: { /* bytevector-append(a, b) */
+    case 684: { /* bytevector-append([a [, b]]) */
         Value b_val = vm_pop(vm), a_val = vm_pop(vm);
+        /* The identity is the EMPTY bytevector, which is what the native
+         * lowering builds for `num_vars == 0` (llvm_codegen.cpp). An omitted
+         * operand contributes nothing to the concatenation. */
+        if (vm_native_absent(a_val) || vm_native_absent(b_val)) {
+            VmBytevector* empty = vm_bv_make(&vm->heap.regions, 0, 0);
+            Value present = vm_native_absent(a_val) ? b_val : a_val;
+            if (vm_native_absent(a_val) && vm_native_absent(b_val)) {
+                if (empty) { VM_PUSH_HEAP_OPAQUE(vm, HEAP_BYTEVECTOR, VAL_BYTEVECTOR, empty); }
+                else vm_push(vm, NIL_VAL);
+                break;
+            }
+            vm_push(vm, present);
+            break;
+        }
         VmBytevector* a = (is_heap_type(vm, a_val, HEAP_BYTEVECTOR))
             ? (VmBytevector*)vm->heap.objects[a_val.as.ptr]->opaque.ptr : NULL;
         VmBytevector* b = (is_heap_type(vm, b_val, HEAP_BYTEVECTOR))
@@ -15520,8 +15579,10 @@ static void vm_dispatch_native(VM* vm, int fid) {
         break; }
     case 216: { Value a = vm_pop(vm); vm_push(vm, INT_VAL((int64_t)as_number(a))); break; } /* char->integer */
     case 217: { Value a = vm_pop(vm); vm_push(vm, (Value){.type = VAL_CHAR, .as.i = (int64_t)as_number(a)}); break; } /* integer->char */
-    case 218: { /* make-vector */
+    case 218: { /* make-vector(k [, fill]) */
         Value fill = vm_pop(vm), size_v = vm_pop(vm);
+        /* `(make-vector 3)` fills with 0 on native (collection_codegen.cpp). */
+        if (vm_native_absent(fill)) fill = INT_VAL(0);
         double requested_size = as_number(size_v);
         if (!isfinite(requested_size) || requested_size < 0.0 ||
             requested_size >= (double)ESHKOL_MAX_VECTOR_CAPACITY ||
@@ -15610,15 +15671,23 @@ static void vm_dispatch_native(VM* vm, int fid) {
         else vm_push(vm, NIL_VAL);
         break;
     }
-    case 224: { /* gcd */
+    case 224: { /* gcd([a [, b]]) */
         Value b = vm_pop(vm), a = vm_pop(vm);
-        int64_t x = llabs((int64_t)as_number(a)), y = llabs((int64_t)as_number(b));
+        /* R7RS 6.2.6: `(gcd)` is 0 and `(gcd n)` is |n| — the identity for the
+         * fold, which is what codegenGCD answers for `num_vars == 0` and why
+         * the row declares itself variadic. */
+        int64_t x = vm_native_absent(a) ? 0 : llabs((int64_t)as_number(a));
+        int64_t y = vm_native_absent(b) ? 0 : llabs((int64_t)as_number(b));
         while (y != 0) { int64_t t = y; y = x % y; x = t; }
         vm_push(vm, INT_VAL(x)); break;
     }
-    case 225: { /* lcm */
+    case 225: { /* lcm([a [, b]]) */
         Value b = vm_pop(vm), a = vm_pop(vm);
-        int64_t x = llabs((int64_t)as_number(a)), y = llabs((int64_t)as_number(b));
+        /* R7RS 6.2.6: `(lcm)` is 1 and `(lcm n)` is |n|, so an omitted operand
+         * is the multiplicative identity rather than a zero that would collapse
+         * the fold. codegenLCM answers the same for `num_vars == 0`. */
+        int64_t x = vm_native_absent(a) ? 1 : llabs((int64_t)as_number(a));
+        int64_t y = vm_native_absent(b) ? 1 : llabs((int64_t)as_number(b));
         if (x == 0 || y == 0) { vm_push(vm, INT_VAL(0)); break; }
         int64_t g = x, h = y;
         while (h != 0) { int64_t t = h; h = g % h; g = t; }
@@ -15731,8 +15800,16 @@ static void vm_dispatch_native(VM* vm, int fid) {
         break;
     }
 
-    case 135: { /* append */
+    case 135: { /* append(a [, b]) */
         Value b = vm_pop(vm), a = vm_pop(vm);
+        /* R7RS 6.4: `(append)` is `()` and `(append lst)` is lst. Both omitted
+         * operands are the empty list, so the copy below terminates on `()`
+         * instead of splicing the absent marker in as the final cdr. The
+         * native engine reaches the same two answers through the core module
+         * that defines it — `(define (append . lists) (cond ((null? lists)
+         * '()) ...))` in lib/core/list/transform.esk. */
+        if (vm_native_absent(a)) a = NIL_VAL;
+        if (vm_native_absent(b)) b = NIL_VAL;
         if (a.type == VAL_NIL) { vm_push(vm, b); break; }
         if (a.type != VAL_PAIR) { vm_push(vm, b); break; }
         /* Copy list a, set last cdr to b */

--- a/scripts/check_builtin_min_arity.py
+++ b/scripts/check_builtin_min_arity.py
@@ -38,16 +38,32 @@ that dispatch checks and reads every number from BUILTINS[] at run time. This
 script closes the loop: each name the backend scopes must still be a row in
 BUILTINS[], or the check silently stops firing for it.
 
-Exit 0 iff no builtin refuses a documented-legal call, no unpinned
-permissiveness gap has appeared, every variadic claim is borne out by its
-native handler, and every builtin the LLVM dispatch scopes is backed by the
-shared table.
+THE NUMBERS ARE DERIVED, AND THIS RE-DERIVES THEM. `min_arity` used to be
+typed in by hand wherever somebody noticed, which is why 739 of 742 rows were
+silently claiming that their opcode's operand count was the caller's
+obligation and the VM refused `(substring s 1)`, `(read-line)` and
+`(make-string 3)` — all legal, all accepted by native.
+scripts/gen_builtin_min_arity.py now derives every row's minimum from the
+fixed-arity macro the native dispatch expands, the arity guard the lowering
+enforces, and the declarative documented signature. This gate imports THAT
+module — not a transcription of it — and fails when the table disagrees with
+what those sources say today, so editing a guard or a signature without
+regenerating the table is a build failure rather than a new divergence.
+
+Exit 0 iff the table matches the derivation, the manifest matches the table,
+no builtin refuses a documented-legal call, no unpinned permissiveness gap has
+appeared, every variadic claim is borne out by its native handler, and every
+builtin the LLVM dispatch scopes is backed by the shared table.
 """
 
 import json
+import os
 import pathlib
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gen_builtin_min_arity  # noqa: E402  — the same derivation, not a copy
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 VM_C = ROOT / "lib" / "backend" / "eshkol_vm.c"
@@ -88,9 +104,19 @@ def builtins_from_source(text):
     out = []
     for name, _native_id, arity, min_arity in ENTRY.findall(m.group(1)):
         arity = int(arity)
-        # "" is an absent field (minimum == arity); a negative value is the
-        # explicit variadic declaration and is carried through as-is.
-        minimum = int(min_arity) if min_arity and int(min_arity) != 0 else arity
+        column = int(min_arity) if min_arity else 0
+        # The min_arity encoding, as BuiltinDef states it: "" or 0 is absent
+        # (the minimum IS arity), -1 declares the native lowering variadic, -2
+        # declares a documented minimum of genuinely zero, and anything else is
+        # the minimum itself. -2 must NOT read as "variadic": `(read-line)` is
+        # a zero-argument call to a one-operand opcode, not a call to a
+        # lowering that folds over however many arguments it is handed.
+        if column == -2:
+            minimum = 0
+        elif column < 0:
+            minimum = column
+        else:
+            minimum = column or arity
         out.append((name, arity, minimum))
     return out
 
@@ -141,23 +167,25 @@ def llvm_scoped_builtins(text):
 def main():
     fixture = ('static const BuiltinDef BUILTINS[] = {\n'
                '{"error",237,1,0,1}, {"hash-ref",661,3,2}, '
-               '{"gcd",45,2,-1}, {"sin",20,1}\n};')
+               '{"gcd",45,2,-1}, {"read-line",585,1,-2}, {"sin",20,1}\n};')
     if builtins_from_source(fixture) != [
-            ('error', 1, 1), ('hash-ref', 3, 2), ('gcd', 2, -1), ('sin', 1, 1)]:
+            ('error', 1, 1), ('hash-ref', 3, 2), ('gcd', 2, -1),
+            ('read-line', 1, 0), ('sin', 1, 1)]:
         print('FAIL: builtin metadata parser dropped or misread a field layout')
         return 1
     if not SURFACE.exists():
         print(f"check_builtin_min_arity: {SURFACE} missing", file=sys.stderr)
         return 2
-    documented = {
-        e["name"]: e.get("arity")
-        for e in json.loads(SURFACE.read_text())["builtins"]
-    }
+    surface = json.loads(SURFACE.read_text())["builtins"]
+    documented = {e["name"]: e.get("arity") for e in surface}
+    surface_minimum = {e["name"]: e.get("min_arity") for e in surface
+                       if "min_arity" in e}
     entries = builtins_from_source(VM_C.read_text())
     if not entries:
         print("check_builtin_min_arity: BUILTINS[] parsed empty", file=sys.stderr)
         return 2
 
+    derived = {r["name"]: r for r in gen_builtin_min_arity.derive(str(ROOT))}
     refusals, permissive, unknown = [], [], []
     declared_variadic = set()
     for name, arity, minimum in entries:
@@ -170,16 +198,64 @@ def main():
         if minimum < 0:
             declared_variadic.add(name)
             continue
+        if derived.get(name, {}).get("min_arity_column") == -2:
+            # A documented minimum of zero: there is no under-arity call to
+            # refuse, and `arity` below is the opcode's operand count rather
+            # than an obligation on the caller.
+            continue
         doc = documented[name]
         if doc is None:
             continue
         if minimum > doc:
             refusals.append((name, arity, minimum, doc))
-        elif minimum < doc and name not in KNOWN_PERMISSIVE:
+        elif (minimum < doc and name not in KNOWN_PERMISSIVE
+                and not derived.get(name, {}).get("min_arity_column")):
+            # A minimum below the opcode's operand count is the NORMAL shape of
+            # a builtin with a documented optional parameter, and the
+            # derivation above is what makes it legitimate. One the derivation
+            # does NOT claim is a row someone shortened by hand.
             permissive.append((name, arity, minimum, doc))
 
     print(f"checked {len(entries)} VM builtin entries against {SURFACE.name}")
     rc = 0
+
+    # (1) THE TABLE MUST STILL BE WHAT THE SOURCES SAY. Re-derive, do not
+    # re-read: a check that trusted the column it is checking would pass
+    # forever after the first wrong value was written.
+    drift = []
+    for name, row in sorted(derived.items()):
+        want = row.get("min_arity_column", row["min_arity"])
+        if row["source"] == "variadic":
+            continue          # -1 is a claim this module verifies separately
+        if want != row["min_arity"]:
+            drift.append((name, row["min_arity"], want, row["source"],
+                          row["evidence"]))
+    for name, have, want, source, evidence in drift:
+        print(
+            f"FAIL: {name} has min_arity {have} in BUILTINS[] but {source} says "
+            f"{want} — re-run scripts/gen_builtin_min_arity.py --apply. "
+            f"Evidence: {evidence[:120]}"
+        )
+        rc = 1
+    if not drift:
+        print(f"  derivation: {len(derived)} rows agree with their native "
+              f"guard / fixed-arity macro / documented signature")
+
+    # (2) THE MANIFEST MUST CARRY THE SAME MINIMUM. tests/coverage/
+    # language_surface.json is what every exposure harness reads, so a
+    # minimum that lives only in the C table is a minimum those harnesses
+    # cannot test against.
+    for name, arity, minimum in entries:
+        if name not in surface_minimum:
+            continue
+        want = None if minimum < 0 else minimum
+        if surface_minimum[name] != want:
+            print(
+                f"FAIL: {name} has caller minimum {want} in BUILTINS[] but "
+                f"{surface_minimum[name]} in {SURFACE.name} — re-run "
+                f"scripts/gen_language_surface.py."
+            )
+            rc = 1
     for name in unknown:
         print(f"FAIL: {name} is in BUILTINS[] but not in the documented surface")
         rc = 1

--- a/scripts/gen_builtin_min_arity.py
+++ b/scripts/gen_builtin_min_arity.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+r"""gen_builtin_min_arity.py — derive the CALLER MINIMUM of every builtin from
+the contracts the compiler and the documentation already state, and write it
+into the `min_arity` column of BUILTINS[] in lib/backend/eshkol_vm.c.
+
+WHY THIS EXISTS. `arity` in BUILTINS[] is the number of operands
+emit_builtin_preamble() loads into the opcode — the SHAPE of the call, not the
+number of arguments a caller must supply. Every builtin with an OPTIONAL
+parameter therefore has an `arity` that over-states its minimum:
+`(substring s 1)`, `(make-string 3)`, `(read-line)` and `(append)` are legal
+calls that the bytecode VM refused, because its under-arity check falls back to
+`arity` whenever a row leaves `min_arity` at 0 — which was 739 rows out of 742.
+`min_arity` exists for exactly this and had been filled in by hand, three times,
+wherever somebody noticed.
+
+Hand-filling 742 rows would reproduce the same defect one transcription later,
+so the numbers are DERIVED, from the two places the contract is already
+written down:
+
+  1. THE NATIVE LOWERING'S OWN ARITY GUARD. `lib/backend/string_io_codegen.cpp`
+     refuses a short `substring` with
+
+         substring requires 2 or 3 arguments: (substring string start [end])
+
+     That sentence is the contract native enforces, it names the optional
+     parameter, and it is machine-readable. ~150 builtins carry one.
+
+  2. A DECLARATIVE DOCUMENTED SIGNATURE — `(string-pad-left s width [char]) —
+     left-pad a string...` in docs/api/**, the public headers, and the
+     reference pages. Bracketed parameters are optional, `...` is variadic.
+
+     EXAMPLE CALLS ARE NOT SIGNATURES. `(make-vector 3)` appears in a hundred
+     documents as something a program does, and reading it as a signature would
+     claim make-vector takes one argument. Only lines of the declarative
+     `(name params) — description` / `- `(name params)` - description` shape are
+     read, and only when the parameters look like parameter NAMES rather than
+     literals.
+
+Where a row has neither, the minimum stays `arity`: that is the status quo, so
+a builtin nobody has documented cannot silently become more permissive.
+
+Both engines consult the result through eshkol_builtin_min_arity()
+(inc/eshkol/core/arity_contract.h), and scripts/check_builtin_min_arity.py
+re-derives it from these same sources and fails the build when the table has
+drifted away from them.
+
+Usage:
+  gen_builtin_min_arity.py                 # report what would change
+  gen_builtin_min_arity.py --apply         # rewrite BUILTINS[] in place
+  gen_builtin_min_arity.py --json OUT      # dump the derivation with evidence
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+VM_C = REPO / "lib" / "backend" / "eshkol_vm.c"
+
+# The min_arity column's encoding, mirroring BuiltinDef in eshkol_vm.c. Zero
+# is "unset — the minimum IS arity", which is what a three-field initialiser
+# produces and what 700 rows rely on, so a builtin whose documented minimum is
+# genuinely ZERO (`(read-line)`, `(read-char)`) cannot say so with a 0 and gets
+# its own marker instead of being silently indistinguishable from the default.
+MIN_IS_ARITY = 0
+MIN_VARIADIC = -1
+MIN_ZERO = -2
+
+# A BuiltinDef row: {"name", id, arity} with optional min_arity and variadic
+# fields. Mirrors the pattern in check_builtin_min_arity.py and
+# gen_language_surface.py — the field layout is load-bearing in all three, and
+# a pattern that cannot see a field drops the builtin from that gate's view.
+ROW = re.compile(
+    r'\{\s*"((?:[^"\\]|\\.)*)"\s*,\s*(-?\d+)\s*,\s*(-?\d+)\s*'
+    r'(?:,\s*(-?\d+)\s*)?(?:,\s*(-?\d+)\s*)?\}')
+
+WORD_NUMBERS = {"zero": 0, "no": 0, "one": 1, "two": 2, "three": 3,
+                "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8}
+
+
+def _count(token):
+    token = token.strip().lower()
+    if token.isdigit():
+        return int(token)
+    return WORD_NUMBERS.get(token)
+
+
+# ── source 1: the native lowering's own arity guard ────────────────────────
+#
+# Ordered: a more specific shape must match before a more general one, or
+# "requires at least 2 arguments" is read by the bare "requires N arguments"
+# rule as an exact 2.
+GUARD_PATTERNS = [
+    (re.compile(r'^(?P<name>\S+?):?\s+(?:requires|expects|takes|needs)\s+at\s+least\s+(?P<lo>\w+)\s+(?:\w+\s+)?arg'), "min"),
+    (re.compile(r'^(?P<name>\S+?):?\s+(?:requires|expects|takes|needs)\s+at\s+most\s+(?P<lo>\w+)\s+arg'), "max"),
+    (re.compile(r'^(?P<name>\S+?):?\s+(?:requires|expects|takes|needs)\s+(?P<lo>\d+)\s*(?:-|–|\s+to\s+|\s+or\s+)\s*(?P<hi>\d+)\s+arg'), "range"),
+    (re.compile(r'^(?P<name>\S+?):?\s+(?:requires|expects|takes|needs)\s+exactly\s+(?P<lo>\w+)\s+(?:\w+\s+)?arg'), "exact"),
+    (re.compile(r'^(?P<name>\S+?):?\s+(?:requires|expects|takes|needs)\s+(?P<lo>\w+)\s+(?:\w+\s+)?arg'), "exact"),
+]
+
+GUARD_SOURCES = ("lib/**/*.cpp", "lib/**/*.c", "lib/**/*.mm", "lib/**/*.h")
+
+
+def guard_minima(repo):
+    """name -> (minimum, evidence) mined from native lowering arity guards.
+
+    A builtin can be guarded in more than one lowering (a fast path and a
+    general one). The SMALLEST stated minimum wins: it is the shortest call
+    native will actually compile, and claiming more would refuse a call the
+    other lowering accepts.
+    """
+    out = {}
+    for pattern in GUARD_SOURCES:
+        for path in sorted(pathlib.Path(repo).glob(pattern)):
+            try:
+                text = path.read_text(errors="replace")
+            except OSError:
+                continue
+            for literal in re.findall(r'"((?:[^"\\]|\\.)*)"', text):
+                if "arg" not in literal:
+                    continue
+                for rx, kind in GUARD_PATTERNS:
+                    m = rx.match(literal)
+                    if not m:
+                        continue
+                    if kind == "max":
+                        break                      # states a ceiling, not a floor
+                    low = _count(m.group("lo"))
+                    if low is None:
+                        break
+                    name = m.group("name")
+                    evidence = "%s: %s" % (
+                        os.path.relpath(path, repo), literal[:110])
+                    prev = out.get(name)
+                    if prev is None or low < prev[0]:
+                        out[name] = (low, evidence)
+                    break
+    return out
+
+
+# ── source 0: the native dispatch's own fixed-arity declaration ────────────
+#
+# lib/backend/system_codegen.cpp declares two hundred builtins through
+# `<N>_ARG_BUILTIN(method, "c_func")` macros, each of which expands to
+# `if (op->call_op.num_vars != N) return tagged_.packNull();`. That is an
+# EXACT arity, stated by the code that runs: `(string-pad-left "a" 3)` does not
+# pad on native, it returns null, because stringPadLeft is a THREE_ARG_BUILTIN.
+#
+# This outranks a documented signature, and where the two disagree the
+# DOCUMENT is the thing that is wrong: `docs/api/backend/system_codegen.md`
+# renders `(string-pad-left s width [char])` from a header comment describing
+# an optional parameter no lowering implements. Believing the bracket would
+# make the VM accept — and silently mis-answer — a call native refuses.
+ARG_COUNT_WORDS = {"ZERO": 0, "ONE": 1, "TWO": 2, "THREE": 3, "FOUR": 4,
+                   "FIVE": 5, "SIX": 6, "SEVEN": 7, "EIGHT": 8}
+
+SYSTEM_CODEGEN = "lib/backend/system_codegen.cpp"
+LLVM_CODEGEN = "lib/backend/llvm_codegen.cpp"
+
+# Two macro families say the same thing: `<N>_ARG_BUILTIN` for the system
+# builtins and `CE_<N>_ARG` for the consciousness-engine ones. Both expand to
+# `if (num_vars != N) return packNull();`. Reading only the first would have
+# left `(fg-infer! g)` and `(make-workspace)` looking optional on the strength
+# of a doc line, when native answers null for both.
+MACRO_INSTANCE = re.compile(
+    r'^(?:CE_)?(ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT)_ARG(?:_BUILTIN)?\(\s*(\w+)\s*,',
+    re.M)
+DISPATCH = re.compile(
+    r'func_name == "((?:[^"\\]|\\.)*)"\)\s*co_return\s+(?:\w+_?->)?(\w+)\(op\)')
+
+
+def fixed_native_arity(repo):
+    """name -> (exact arity, evidence) for every builtin the native dispatch
+    lowers through a fixed-arity macro."""
+    repo = pathlib.Path(repo)
+    system = (repo / SYSTEM_CODEGEN)
+    llvm = (repo / LLVM_CODEGEN)
+    if not system.exists() or not llvm.exists():
+        return {}
+    by_method = {}
+    for words, method in MACRO_INSTANCE.findall(system.read_text(errors="replace")):
+        by_method[method] = ARG_COUNT_WORDS[words]
+    out = {}
+    for name, method in DISPATCH.findall(llvm.read_text(errors="replace")):
+        if method in by_method:
+            out[name] = (by_method[method],
+                         "%s: %s is a %s_ARG_BUILTIN"
+                         % (SYSTEM_CODEGEN, method,
+                            [w for w, n in ARG_COUNT_WORDS.items()
+                             if n == by_method[method]][0]))
+    return out
+
+
+# ── source 1a: a native lowering with an explicit ZERO-ARGUMENT case ───────
+#
+# A lowering that opens with the identity for an empty call is variadic with a
+# documented minimum of zero, and it says so in code:
+#
+#     if (func_name == "bytevector-append") {
+#         uint64_t n = op->call_op.num_vars;
+#         if (n == 0) { ... an empty bytevector ... co_return ...; }
+#
+# `(bytevector-append)` therefore answers the empty bytevector on native, and
+# the VM refused it. This is the same test check_builtin_min_arity.py already
+# applies to a row that DECLARES itself variadic — a `num_vars == 0` case in
+# the handler — applied to every name the dispatch lowers inline rather than
+# only to the two names a human listed.
+#
+# A zero-argument case that REFUSES is not an identity, so a branch that
+# errors, warns, or answers null is not read as one.
+ZERO_CASE_REFUSES = ("eshkol_error", "eshkol_arity_error", "eshkol_warn",
+                     "markFatalCodegenError", "packNull", "nullptr")
+
+
+def _brace_block(text, open_index):
+    depth, i = 0, open_index
+    while i < len(text):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_index + 1:i]
+        i += 1
+    return ""
+
+
+def zero_argument_lowerings(repo):
+    """name -> (0, evidence) for builtins whose inline lowering answers a
+    zero-argument call with a value."""
+    path = pathlib.Path(repo) / LLVM_CODEGEN
+    if not path.exists():
+        return {}
+    text = path.read_text(errors="replace")
+    out = {}
+    for m in re.finditer(r'func_name == "((?:[^"\\]|\\.)*)"\)\s*\{', text):
+        body = _brace_block(text, m.end() - 1)
+        if not body:
+            continue
+        # The count may be read into a local first (`uint64_t n = num_vars;`).
+        aliases = {"num_vars"}
+        for alias in re.finditer(r'\b(\w+)\s*=\s*[^;]*call_op\.num_vars', body):
+            aliases.add(alias.group(1))
+        for alias in sorted(aliases):
+            zero = re.search(r'\b%s\s*==\s*0\s*\)\s*\{' % re.escape(alias), body)
+            if not zero:
+                continue
+            branch = _brace_block(body, zero.end() - 1)
+            if not branch or not re.search(r'\bco_return\b|\breturn\b', branch):
+                continue
+            if any(bad in branch for bad in ZERO_CASE_REFUSES):
+                continue
+            out[m.group(1)] = (0, "%s: `%s` lowering answers %s == 0 with a value"
+                               % (LLVM_CODEGEN, m.group(1), alias))
+            break
+    return out
+
+
+# ── source 1b: the Scheme definition the native engine compiles ────────────
+#
+# Several public procedures are not lowered by the backend at all — native
+# reaches them through the core modules compiled into every program. `append`
+# is one: lib/core/list/transform.esk defines
+#
+#     (define (append . lists)
+#       (cond ((null? lists) '())
+#             ...
+#
+# a rest-argument lambda with ZERO required parameters whose first clause IS
+# the R7RS identity for `(append)`. That is not a description of the contract,
+# it is the code that answers the call, so it outranks any prose. A guard or a
+# fixed-arity macro still outranks IT, because those belong to a lowering that
+# shadows the module definition.
+SCHEME_SOURCES = ("lib/**/*.esk",)
+
+SCHEME_DEFINE = re.compile(
+    r'\(define\s+\(\s*([a-zA-Z0-9_!?*<>=/+%^~.$&:@\-]+)((?:[^()\n]|\([^()]*\))*)\)')
+
+
+def scheme_minima(repo):
+    """name -> (minimum, evidence) for rest-argument procedures defined in the
+    core Scheme modules. A definition WITHOUT a rest argument states an exact
+    arity and is not a claim about optionality, so only `(name . rest)` and
+    `(name a b . rest)` are read here."""
+    out = {}
+    for pattern in SCHEME_SOURCES:
+        for path in sorted(pathlib.Path(repo).glob(pattern)):
+            try:
+                text = path.read_text(errors="replace")
+            except OSError:
+                continue
+            for m in SCHEME_DEFINE.finditer(text):
+                params = m.group(2)
+                if "." not in params:
+                    continue                     # fixed arity: no claim to make
+                fixed = params.split(".")[0].split()
+                if any(not PARAM.match(tok) for tok in fixed):
+                    continue
+                name = m.group(1)
+                evidence = "%s: (define (%s%s) …)" % (
+                    os.path.relpath(path, repo), name, params.rstrip())
+                prev = out.get(name)
+                if prev is None or len(fixed) < prev[0]:
+                    out[name] = (len(fixed), evidence)
+    return out
+
+
+# ── source 2: a declarative documented signature ───────────────────────────
+#
+# `(name a b [c]) — description`  (docs/api/**, public headers)
+# `- `(name a b [c])` - description`  (reference pages, the language spec)
+DOC_SOURCES = ("docs/**/*.md", "inc/**/*.h", "inc/**/*.hpp")
+
+_SIG_BODY = r'([a-zA-Z0-9_!?*<>=/+%^~.$&:@\-]+)((?:[^()]|\([^()]*\))*)'
+DOC_SIGNATURE_FORMS = [
+    re.compile(r'^\(' + _SIG_BODY + r'\)\s*[—–]\s*\S'),          # (f a b) — desc
+    re.compile(r'^-\s+`\(' + _SIG_BODY + r'\)`\s*[-—–:]\s*\S'),  # - `(f a b)` - desc
+    re.compile(r'^`\(' + _SIG_BODY + r'\)`\s*[—–]\s*\S'),        # `(f a b)` — desc
+    re.compile(r'^\*\*`?\(' + _SIG_BODY + r'\)`?\*\*\s*[-—–:]\s*\S'),
+]
+
+# A parameter NAME. Literals (`3`, `"s"`, `#t`, `'sym`) mean the line is an
+# example call, not a signature, and the whole line is discarded.
+PARAM = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_?!*<>=/+.\-]*$')
+ELLIPSIS = {"...", "....", "…", ".", "·"}
+
+
+def parse_signature(params_text):
+    """(minimum, variadic) for a signature body, or None if it is not one.
+
+    Bracketed parameters are optional and everything after the first optional
+    is optional too; `...` and a trailing `x...` are variadic. A token that is
+    not a plain identifier (a number, a string, a quote) means the line was an
+    example call and the caller must discard it.
+    """
+    tokens, current, depth = [], "", 0
+    for ch in params_text:
+        if ch == "[":
+            depth += 1
+            current += ch
+        elif ch == "]":
+            depth -= 1
+            current += ch
+        elif ch.isspace() and depth == 0:
+            if current:
+                tokens.append(current)
+                current = ""
+        else:
+            current += ch
+    if current:
+        tokens.append(current)
+
+    minimum, variadic, seen_optional, named = 0, False, False, 0
+    for token in tokens:
+        if token.startswith("["):
+            seen_optional = True
+            continue
+        if token in ELLIPSIS or token.endswith("..."):
+            # A repeated parameter (`lst...`, `dim...`) states a MAXIMUM, not a
+            # minimum: these pages write `(ones dim...)` for a procedure whose
+            # native lowering refuses `(ones)` outright ("ones requires at
+            # least 1 dimension argument"). So the repetition is recorded as
+            # variadic and the parameter still counts as required; only an
+            # explicit `[bracket]` — or a native guard, which outranks the doc
+            # — lowers a minimum.
+            variadic = True
+            if token not in ELLIPSIS:
+                named += 1
+                if not seen_optional:
+                    minimum += 1
+            continue
+        if not PARAM.match(token):
+            return None                      # an example call, not a signature
+        named += 1
+        if seen_optional:
+            continue                         # a required param after an optional
+        minimum += 1                         # one is a documentation bug, not ours
+    if tokens and named == 0:
+        # `(http-request ...)` and `(make-temp-file ...)` are PROSE — a page
+        # saying "and its arguments" — not a claim that the procedure takes
+        # none. Read as a signature they would set the minimum to zero and the
+        # VM would stop refusing `(http-request)`, which native refuses. A body
+        # that is EMPTY is a real nullary signature and stays one; a body that
+        # is nothing but an ellipsis is discarded.
+        return None
+    return minimum, variadic
+
+
+def doc_minima(repo):
+    """name -> (minimum, evidence) from declarative documented signatures.
+
+    The SMALLEST documented minimum wins for the same reason it does among
+    guards: two pages describing the same procedure at different arities are
+    describing one procedure whose extra parameters are optional.
+    """
+    out = {}
+    for pattern in DOC_SOURCES:
+        for path in sorted(pathlib.Path(repo).glob(pattern)):
+            try:
+                text = path.read_text(errors="replace")
+            except OSError:
+                continue
+            for raw in text.splitlines():
+                line = raw.strip().lstrip("*").strip()
+                for rx in DOC_SIGNATURE_FORMS:
+                    m = rx.match(line)
+                    if not m:
+                        continue
+                    parsed = parse_signature(m.group(2))
+                    if parsed is None:
+                        break
+                    name = m.group(1)
+                    evidence = "%s: %s" % (
+                        os.path.relpath(path, repo), line[:110])
+                    prev = out.get(name)
+                    if prev is None or parsed[0] < prev[0]:
+                        out[name] = (parsed[0], evidence)
+                    break
+    return out
+
+
+def table_rows(text):
+    m = re.search(r"static const BuiltinDef BUILTINS\[\] = \{(.*?)\n\};", text, re.S)
+    if not m:
+        raise SystemExit("gen_builtin_min_arity: BUILTINS[] not found in eshkol_vm.c")
+    rows = []
+    for name, native_id, arity, min_arity, variadic in ROW.findall(m.group(1)):
+        if not name:
+            continue
+        rows.append({
+            "name": name,
+            "native_id": int(native_id),
+            "arity": int(arity),
+            "min_arity": int(min_arity) if min_arity else 0,
+            "variadic": int(variadic) if variadic else 0,
+        })
+    return rows
+
+
+def derive(repo):
+    """Return the derivation for every BUILTINS[] row.
+
+    `minimum` is what the row's min_arity column should say: 0 when the
+    minimum IS the opcode's operand count (the common case, and the cheapest
+    thing to write), a positive number when a documented optional parameter
+    makes the real minimum smaller, and the row's existing negative value when
+    it declares itself variadic in the native lowering.
+    """
+    repo = pathlib.Path(repo)
+    rows = table_rows(VM_C.read_text() if repo == REPO
+                      else (repo / "lib/backend/eshkol_vm.c").read_text())
+    guards, docs = guard_minima(repo), doc_minima(repo)
+    fixed = fixed_native_arity(repo)
+    zero_case = zero_argument_lowerings(repo)
+    scheme = scheme_minima(repo)
+    out = []
+    for row in rows:
+        name, arity = row["name"], row["arity"]
+        record = dict(row, source="table", evidence="", derived=arity,
+                      documented=None)
+        if row["min_arity"] == MIN_VARIADIC:
+            # A variadic declaration is a claim about the native lowering that
+            # check_builtin_min_arity.py verifies against the handler itself;
+            # nothing here can second-guess it. Note only -1 is carried over:
+            # every other column value is RE-DERIVED from the sources below, so
+            # running this generator twice produces the same table as running it
+            # once — a generator that read its own last answer as evidence would
+            # freeze whatever it wrote first, mistakes included.
+            record.update(source="variadic", derived=row["min_arity"])
+            out.append(record)
+            continue
+        for source, table in (("native-fixed", fixed), ("zero-case", zero_case),
+                              ("guard", guards), ("scheme", scheme),
+                              ("doc", docs)):
+            if name in table:
+                minimum, evidence = table[name]
+                record.update(source=source, evidence=evidence,
+                              documented=minimum)
+                break
+        # A documented optional parameter that the native lowering does not
+        # implement is a DOCUMENTATION DEFECT, and the table must not act on
+        # it. Record it so the report can name the page to fix.
+        if record["source"] == "native-fixed" and name in docs:
+            doc_minimum, doc_evidence = docs[name]
+            if doc_minimum < record["documented"]:
+                record["doc_conflict"] = {
+                    "documented_minimum": doc_minimum,
+                    "native_exact": record["documented"],
+                    "evidence": doc_evidence,
+                }
+        documented = record["documented"]
+        if documented is None or documented >= arity:
+            # No evidence, or evidence that agrees with the opcode's operand
+            # count. Either way the row makes no separate claim.
+            record["derived"] = arity
+            record["min_arity_column"] = MIN_IS_ARITY
+        else:
+            record["derived"] = documented
+            record["min_arity_column"] = MIN_ZERO if documented == 0 else documented
+        out.append(record)
+    return out
+
+
+def render_row(record):
+    """The BuiltinDef initialiser for one row, in the table's own shape."""
+    fields = ['"%s"' % record["name"], str(record["native_id"]), str(record["arity"])]
+    column = record.get("min_arity_column", record["min_arity"])
+    if record["source"] == "variadic":
+        column = record["min_arity"]
+    if column or record["variadic"]:
+        fields.append(str(column))
+    if record["variadic"]:
+        fields.append(str(record["variadic"]))
+    return "{" + ", ".join(fields) + "}"
+
+
+def apply(records, path):
+    """Rewrite each BUILTINS[] initialiser in place, preserving the table's
+    layout: only the initialiser text of a row whose min_arity column changes
+    is touched, so the comments and the grouping survive."""
+    text = path.read_text()
+    m = re.search(r"(static const BuiltinDef BUILTINS\[\] = \{)(.*?)(\n\};)", text, re.S)
+    body = m.group(2)
+    by_position = list(ROW.finditer(body))
+    lookup = {r["name"]: r for r in records}
+    pieces, last, changed = [], 0, 0
+    for match in by_position:
+        name = match.group(1)
+        record = lookup.get(name)
+        if record is None or not name:
+            continue
+        replacement = render_row(record)
+        if replacement == match.group(0):
+            continue
+        pieces.append(body[last:match.start()])
+        pieces.append(replacement)
+        last = match.end()
+        changed += 1
+    pieces.append(body[last:])
+    path.write_text(text[:m.start(2)] + "".join(pieces) + text[m.end(2):])
+    return changed
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default=str(REPO))
+    ap.add_argument("--apply", action="store_true",
+                    help="rewrite BUILTINS[] in lib/backend/eshkol_vm.c")
+    ap.add_argument("--json", help="write the full derivation, with evidence")
+    args = ap.parse_args()
+
+    records = derive(args.repo)
+    changes = [r for r in records
+               if r.get("min_arity_column", r["min_arity"]) != r["min_arity"]]
+    optional = [r for r in records if r.get("min_arity_column")]
+    print("BUILTINS[] rows                : %d" % len(records))
+    print("rows with a documented optional: %d" % len(optional))
+    print("rows whose column changes      : %d" % len(changes))
+    by_source = {}
+    for r in optional:
+        by_source[r["source"]] = by_source.get(r["source"], 0) + 1
+    for source in sorted(by_source):
+        print("  from %-6s: %d" % (source, by_source[source]))
+    conflicts = [r for r in records if r.get("doc_conflict")]
+    if conflicts:
+        print("documented optionals the native lowering does not implement: %d"
+              % len(conflicts))
+        for r in sorted(conflicts, key=lambda r: r["name"]):
+            c = r["doc_conflict"]
+            print("  %-28s doc minimum %d vs native exact %d — %s"
+                  % (r["name"], c["documented_minimum"], c["native_exact"],
+                     c["evidence"][:90]))
+    for r in sorted(changes, key=lambda r: r["name"]):
+        print("  %-28s arity %d -> minimum %d   [%s] %s"
+              % (r["name"], r["arity"], r["derived"], r["source"],
+                 r["evidence"][:90]))
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(records, indent=1))
+        print("wrote %s" % args.json)
+    if args.apply:
+        n = apply(records, pathlib.Path(args.repo) / "lib/backend/eshkol_vm.c")
+        print("rewrote %d BUILTINS[] rows" % n)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen_language_surface.py
+++ b/scripts/gen_language_surface.py
@@ -153,16 +153,35 @@ def _slice_table(path, start_marker, end_marker_after):
     return text[i:j]
 
 
+def resolve_min_arity(arity, column):
+    """The CALLER minimum a BuiltinDef row states, from its min_arity column.
+
+    Mirrors vm_builtin_row_min_arity() in lib/backend/eshkol_vm.c — 0 means
+    "the minimum IS arity", -1 means the native lowering is variadic and the
+    row makes no claim, -2 means the documented minimum is genuinely zero.
+    Keeping the manifest's number the CALLER's obligation rather than the
+    opcode's operand count is the whole point: `arity` says `substring` takes
+    three operands, and `(substring s 1)` is still a legal call.
+    """
+    if column == -1:
+        return None
+    if column == -2:
+        return 0
+    return column if column else arity
+
+
 def extract_builtin_table(path):
-    """Extract {name: {id, arity}} from a `static const BuiltinDef BUILTINS[]`."""
+    """Extract {name: {id, arity, min_arity}} from `static const BuiltinDef BUILTINS[]`."""
     body = _slice_table(path, "BuiltinDef BUILTINS[]", "\n};")
     out = {}
     for m in BUILTIN_ROW.finditer(body):
         name, nid, arity = m.group(1), int(m.group(2)), int(m.group(3))
+        column = int(m.group(4)) if m.group(4) else 0
         if name == "NULL":
             continue
         # A name may appear with several ids (overloads / legacy+new). Keep all.
-        rec = out.setdefault(name, {"ids": [], "arity": arity})
+        rec = out.setdefault(name, {"ids": [], "arity": arity,
+                                    "min_arity": resolve_min_arity(arity, column)})
         if nid not in rec["ids"]:
             rec["ids"].append(nid)
     return out
@@ -581,9 +600,12 @@ def build_manifest():
                                  *(set(vm.get(m, {}).get("ids", []))
                                    for m in member_names)))
         arity = None
+        minimum = None
         for m in member_names:
-            arity = comp.get(m, vm.get(m, {})).get("arity")
+            source = comp.get(m, vm.get(m, {}))
+            arity = source.get("arity")
             if arity is not None:
+                minimum = vm.get(m, {}).get("min_arity", arity)
                 break
         backends = []
         if in_c:
@@ -596,6 +618,10 @@ def build_manifest():
             "name": name,
             "ids": ids,
             "arity": arity,
+            # The CALLER's minimum, which is what a wrong-arity check must
+            # read; `arity` above is the opcode's operand count and over-states
+            # it for every builtin with a documented optional parameter.
+            "min_arity": minimum,
             "backends": backends,
             "category": categorize(name),
         }
@@ -634,6 +660,7 @@ def build_manifest():
             "name": name,
             "ids": [],
             "arity": arity,
+            "min_arity": arity,
             "backends": ["agent_ffi"],
             "category": category,
             "source": os.path.relpath(path, REPO),

--- a/tests/coverage/language_surface.json
+++ b/tests/coverage/language_surface.json
@@ -174,6 +174,7 @@
       "name": "%",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -183,6 +184,7 @@
       "name": "%make-lazy-promise",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -192,6 +194,7 @@
       "name": "%make-lazy-promise-force",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -201,6 +204,7 @@
       "name": "*",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -210,6 +214,7 @@
       "name": "+",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -219,6 +224,7 @@
       "name": "-",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -228,6 +234,7 @@
       "name": "/",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -237,6 +244,7 @@
       "name": "/rational",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -248,6 +256,7 @@
         146
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -260,6 +269,7 @@
         148
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -272,6 +282,7 @@
         150
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -284,6 +295,7 @@
         147
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -296,6 +308,7 @@
         149
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -306,6 +319,7 @@
       "name": "__eshkol_parameter_convert",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -315,6 +329,7 @@
       "name": "__eshkol_parameter_pop",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -324,6 +339,7 @@
       "name": "__eshkol_parameter_push",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -335,6 +351,7 @@
         31
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -346,6 +363,7 @@
         250
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -357,6 +375,7 @@
         1996
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -369,6 +388,7 @@
         2035
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -382,6 +402,7 @@
         507
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -393,6 +414,7 @@
         520
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -404,6 +426,7 @@
         34
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -415,6 +438,7 @@
         33
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -426,6 +450,7 @@
         2230
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -438,6 +463,7 @@
         51
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -449,6 +475,7 @@
         588
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm"
       ],
@@ -460,6 +487,7 @@
         619
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -471,6 +499,7 @@
         2211
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -482,6 +511,7 @@
         2210
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -493,6 +523,7 @@
         554
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -504,6 +535,7 @@
         459
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -515,6 +547,7 @@
         458
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -526,6 +559,7 @@
         460
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -537,6 +571,7 @@
         457
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -548,6 +583,7 @@
         212
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -559,6 +595,7 @@
         618
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -570,6 +607,7 @@
         35
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -581,6 +619,7 @@
       "name": "acons",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -592,6 +631,7 @@
         30
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -603,6 +643,7 @@
       "name": "acosh",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -614,6 +655,7 @@
         404
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -626,6 +668,7 @@
         394
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -638,6 +681,7 @@
         408
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -650,6 +694,7 @@
         391
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -662,6 +707,7 @@
         399
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -674,6 +720,7 @@
         2087
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -686,6 +733,7 @@
         397
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -698,6 +746,7 @@
         400
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -710,6 +759,7 @@
         2086
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -722,6 +772,7 @@
         409
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -734,6 +785,7 @@
         409
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -746,6 +798,7 @@
         401
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -758,6 +811,7 @@
         396
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -770,6 +824,7 @@
         403
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -782,6 +837,7 @@
         1842
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -794,6 +850,7 @@
         2088
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -806,6 +863,7 @@
         1844
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -818,6 +876,7 @@
         2083
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -830,6 +889,7 @@
         405
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -842,6 +902,7 @@
         2082
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -854,6 +915,7 @@
         2084
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -866,6 +928,7 @@
         2089
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -879,6 +942,7 @@
         406
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -891,6 +955,7 @@
         398
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -903,6 +968,7 @@
         402
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -915,6 +981,7 @@
         395
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -927,6 +994,7 @@
         407
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -939,6 +1007,7 @@
         2085
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -951,6 +1020,7 @@
         1843
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -963,6 +1033,7 @@
         390
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -975,6 +1046,7 @@
         1841
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -987,6 +1059,7 @@
         2090
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -1000,6 +1073,7 @@
         1842
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -1012,6 +1086,7 @@
         1842
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -1024,6 +1099,7 @@
         392
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -1034,6 +1110,7 @@
       "name": "adagrad-step",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1043,6 +1120,7 @@
       "name": "adam-step",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1052,6 +1130,7 @@
       "name": "adamw-step",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1063,6 +1142,7 @@
         856
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -1074,6 +1154,7 @@
         142
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -1084,6 +1165,7 @@
       "name": "addr-of",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1095,6 +1177,7 @@
         1953
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1108,6 +1191,7 @@
         305
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1121,6 +1205,7 @@
         1946
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1135,6 +1220,7 @@
         900
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -1147,6 +1233,7 @@
         135
       ],
       "arity": 2,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -1157,6 +1244,7 @@
       "name": "append-file",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1168,6 +1256,7 @@
         70
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -1181,6 +1270,7 @@
         419
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1195,6 +1285,7 @@
         1696
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -1208,6 +1299,7 @@
         29
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1219,6 +1311,7 @@
       "name": "asinh",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1230,6 +1323,7 @@
         138
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -1242,6 +1336,7 @@
         2031
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -1254,6 +1349,7 @@
         31
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -1264,6 +1360,7 @@
       "name": "atan2",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1273,6 +1370,7 @@
       "name": "atanh",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1282,6 +1380,7 @@
       "name": "atomic-compare-exchange!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1291,6 +1390,7 @@
       "name": "atomic-exchange!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1300,6 +1400,7 @@
       "name": "atomic-fetch-add!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1309,6 +1410,7 @@
       "name": "atomic-fetch-and!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1318,6 +1420,7 @@
       "name": "atomic-fetch-or!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1327,6 +1430,7 @@
       "name": "atomic-fetch-sub!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1336,6 +1440,7 @@
       "name": "atomic-fetch-xor!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1345,6 +1450,7 @@
       "name": "atomic-load",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1354,6 +1460,7 @@
       "name": "atomic-store!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1363,6 +1470,7 @@
       "name": "avg-pool2d",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1374,6 +1482,7 @@
         2081
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1386,6 +1495,7 @@
         2080
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1398,6 +1508,7 @@
         1962
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1411,6 +1522,7 @@
         1961
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1424,6 +1536,7 @@
         448
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -1434,6 +1547,7 @@
       "name": "batch-norm",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1443,6 +1557,7 @@
       "name": "bce-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1452,6 +1567,7 @@
       "name": "binary-cross-entropy-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1461,6 +1577,7 @@
       "name": "binary-port?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1472,6 +1589,7 @@
         2202
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1484,6 +1602,7 @@
         2200
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -1496,6 +1615,7 @@
         2201
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -1509,6 +1629,7 @@
         1692
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -1523,6 +1644,7 @@
         1695
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1537,6 +1659,7 @@
         1693
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -1551,6 +1674,7 @@
         1694
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -1564,6 +1688,7 @@
         236
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -1578,6 +1703,7 @@
         208
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1589,6 +1715,7 @@
       "name": "bytevector",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1600,6 +1727,7 @@
         684
       ],
       "arity": 2,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -1612,6 +1740,7 @@
         687
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1624,6 +1753,7 @@
         685
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -1636,6 +1766,7 @@
         681
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1648,6 +1779,7 @@
         682
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -1660,6 +1792,7 @@
         683
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -1672,6 +1805,7 @@
         686
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1684,6 +1818,7 @@
         89
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1695,6 +1830,7 @@
         90
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1706,6 +1842,7 @@
         82
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1718,6 +1855,7 @@
         91
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1729,6 +1867,7 @@
         92
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1740,6 +1879,7 @@
         83
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1752,6 +1892,7 @@
         79
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1765,6 +1906,7 @@
         93
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1776,6 +1918,7 @@
         94
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1787,6 +1930,7 @@
         84
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1799,6 +1943,7 @@
         95
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1810,6 +1955,7 @@
         96
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1822,6 +1968,7 @@
         80
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1835,6 +1982,7 @@
         77
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1846,6 +1994,7 @@
       "name": "call-with-input-file",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1855,6 +2004,7 @@
       "name": "call-with-output-file",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1864,6 +2014,7 @@
       "name": "call-with-port",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1876,6 +2027,7 @@
         200
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -1887,6 +2039,7 @@
       "name": "causal-mask",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1896,6 +2049,7 @@
       "name": "cbrt",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -1907,6 +2061,7 @@
         97
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1918,6 +2073,7 @@
         98
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1929,6 +2085,7 @@
         85
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1941,6 +2098,7 @@
         99
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1952,6 +2110,7 @@
         102
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1963,6 +2122,7 @@
         86
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1975,6 +2135,7 @@
         81
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -1987,6 +2148,7 @@
         103
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -1998,6 +2160,7 @@
         104
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -2009,6 +2172,7 @@
         87
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -2021,6 +2185,7 @@
         105
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -2032,6 +2197,7 @@
         106
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -2043,6 +2209,7 @@
         88
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -2055,6 +2222,7 @@
         78
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2069,6 +2237,7 @@
         201
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2080,6 +2249,7 @@
       "name": "ceil",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2091,6 +2261,7 @@
         27
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2102,6 +2273,7 @@
       "name": "celu",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2113,6 +2285,7 @@
         2005
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -2125,6 +2298,7 @@
         2003
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -2137,6 +2311,7 @@
         2003
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -2149,6 +2324,7 @@
         2002
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -2161,6 +2337,7 @@
         2004
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -2173,6 +2350,7 @@
         2004
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -2186,6 +2364,7 @@
         216
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2200,6 +2379,7 @@
         1680
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2211,6 +2391,7 @@
       "name": "char-ci<=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2220,6 +2401,7 @@
       "name": "char-ci<?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2229,6 +2411,7 @@
       "name": "char-ci=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2238,6 +2421,7 @@
       "name": "char-ci>=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2247,6 +2431,7 @@
       "name": "char-ci>?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2259,6 +2444,7 @@
         1686
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2270,6 +2456,7 @@
       "name": "char-foldcase",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2282,6 +2469,7 @@
         1684
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2296,6 +2484,7 @@
         1681
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2307,6 +2496,7 @@
       "name": "char-ready?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2319,6 +2509,7 @@
         1685
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2333,6 +2524,7 @@
         1683
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2347,6 +2539,7 @@
         1682
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2358,6 +2551,7 @@
       "name": "char<=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2370,6 +2564,7 @@
         1688
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -2384,6 +2579,7 @@
         1687
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -2395,6 +2591,7 @@
       "name": "char>=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2407,6 +2604,7 @@
         1689
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -2420,6 +2618,7 @@
         161
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2431,6 +2630,7 @@
       "name": "check-grad-health",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2442,6 +2642,7 @@
         830
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -2451,6 +2652,7 @@
       "name": "clip-grad-norm!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2460,6 +2662,7 @@
       "name": "close-input-port",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2469,6 +2672,7 @@
       "name": "close-output-port",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2480,6 +2684,7 @@
         582
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2493,6 +2698,7 @@
         602
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -2503,6 +2709,7 @@
       "name": "compiler-fence",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2514,6 +2721,7 @@
         317
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2527,6 +2735,7 @@
         2017
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -2538,6 +2747,7 @@
       "name": "concatenate",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2549,6 +2759,7 @@
         2013
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -2561,6 +2772,7 @@
         2012
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -2573,6 +2785,7 @@
         2011
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -2585,6 +2798,7 @@
         2013
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -2597,6 +2811,7 @@
         2012
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -2609,6 +2824,7 @@
         2011
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -2621,6 +2837,7 @@
         306
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2635,6 +2852,7 @@
         202
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -2648,6 +2866,7 @@
         1964
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -2659,6 +2878,7 @@
       "name": "contrastive-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2668,6 +2888,7 @@
       "name": "conv1d",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2679,6 +2900,7 @@
         465
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "native_llvm"
@@ -2689,6 +2911,7 @@
       "name": "conv3d",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2700,6 +2923,7 @@
         21
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2713,6 +2937,7 @@
         720
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -2724,6 +2949,7 @@
       "name": "cosine-annealing-lr",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2733,6 +2959,7 @@
       "name": "cosine-embedding-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2744,6 +2971,7 @@
         1707
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -2756,6 +2984,7 @@
         480
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -2770,6 +2999,7 @@
         754
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -2782,6 +3012,7 @@
         1703
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -2792,6 +3023,7 @@
       "name": "current-environment",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2803,6 +3035,7 @@
         1714
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -2813,6 +3046,7 @@
       "name": "current-input-port",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2822,6 +3056,7 @@
       "name": "current-jiffy",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2831,6 +3066,7 @@
       "name": "current-output-port",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2840,6 +3076,7 @@
       "name": "current-second",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2849,6 +3086,7 @@
       "name": "current-seconds",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2858,6 +3096,7 @@
       "name": "current-time",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2869,6 +3108,7 @@
         1709
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -2881,6 +3121,7 @@
         1973
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -2894,6 +3135,7 @@
         1972
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -2907,6 +3149,7 @@
         852
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -2918,6 +3161,7 @@
         855
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -2929,6 +3173,7 @@
         846
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -2938,6 +3183,7 @@
       "name": "dataloader-has-next?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2950,6 +3196,7 @@
       "name": "dataloader-length",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2959,6 +3206,7 @@
       "name": "dataloader-next",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2968,6 +3216,7 @@
       "name": "dataloader-reset",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2977,6 +3226,7 @@
       "name": "dataloader-reset!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -2988,6 +3238,7 @@
         2028
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3000,6 +3251,7 @@
         2030
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3012,6 +3264,7 @@
         2029
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3024,6 +3277,7 @@
         2027
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3036,6 +3290,7 @@
         2018
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3047,6 +3302,7 @@
       "name": "delete-directory",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3058,6 +3314,7 @@
         600
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -3071,6 +3328,7 @@
         347
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3082,6 +3340,7 @@
       "name": "dequant-q4_0",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3091,6 +3350,7 @@
       "name": "dequant-q8_0",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3102,6 +3362,7 @@
         393
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3114,6 +3375,7 @@
         758
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -3125,6 +3387,7 @@
         393
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3137,6 +3400,7 @@
         1978
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3148,6 +3412,7 @@
       "name": "digit-value",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3159,6 +3424,7 @@
         756
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -3170,6 +3436,7 @@
         1749
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -3182,6 +3449,7 @@
         601
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -3191,6 +3459,7 @@
       "name": "directory-exists?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3200,6 +3469,7 @@
       "name": "directory-list",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3211,6 +3481,7 @@
         1748
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -3224,6 +3495,7 @@
         240
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3237,6 +3509,7 @@
         2067
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3250,6 +3523,7 @@
         145
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3263,6 +3537,7 @@
         753
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3275,6 +3550,7 @@
         2034
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3287,6 +3563,7 @@
         2032
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3299,6 +3576,7 @@
         2033
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3312,6 +3590,7 @@
         904
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3324,6 +3603,7 @@
         470
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "native_llvm"
@@ -3337,6 +3617,7 @@
         375
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3350,6 +3631,7 @@
         373
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3363,6 +3645,7 @@
         374
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3376,6 +3659,7 @@
         378
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3389,6 +3673,7 @@
         372
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3402,6 +3687,7 @@
         379
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3415,6 +3701,7 @@
         380
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3427,6 +3714,7 @@
         371
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3440,6 +3728,7 @@
         377
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3453,6 +3742,7 @@
         381
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3465,6 +3755,7 @@
         372
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3478,6 +3769,7 @@
         371
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3491,6 +3783,7 @@
         376
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3504,6 +3797,7 @@
         1849
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3515,6 +3809,7 @@
       "name": "einsum",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3524,6 +3819,7 @@
       "name": "elu",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3533,6 +3829,7 @@
       "name": "embedding",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3542,6 +3839,7 @@
       "name": "emergency-exit",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3551,6 +3849,7 @@
       "name": "eof-object",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3562,6 +3861,7 @@
         592
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3575,6 +3875,7 @@
         133
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3588,6 +3889,7 @@
         134
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3601,6 +3903,7 @@
         133
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3614,6 +3917,7 @@
         237
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3627,6 +3931,7 @@
         713
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3641,6 +3946,7 @@
         712
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3655,6 +3961,7 @@
         714
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3666,6 +3973,7 @@
       "name": "eval",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3677,6 +3985,7 @@
         43
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3690,6 +3999,7 @@
         2221
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -3703,6 +4013,7 @@
         2225
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -3716,6 +4027,7 @@
         2224
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3729,6 +4041,7 @@
         2223
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3742,6 +4055,7 @@
         2222
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3756,6 +4070,7 @@
         901
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -3768,6 +4083,7 @@
         191
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -3782,6 +4098,7 @@
         343
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3793,6 +4110,7 @@
       "name": "exact-integer?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3802,6 +4120,7 @@
       "name": "exact-rational?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3813,6 +4132,7 @@
         162
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3826,6 +4146,7 @@
         1708
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -3838,6 +4159,7 @@
         1949
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3851,6 +4173,7 @@
         1799
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3864,6 +4187,7 @@
         2097
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -3876,6 +4200,7 @@
         23
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3887,6 +4212,7 @@
       "name": "exp2",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3898,6 +4224,7 @@
         526
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -3908,6 +4235,7 @@
       "name": "exponential-decay-lr",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3919,6 +4247,7 @@
         32
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -3932,6 +4261,7 @@
         835
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -3943,6 +4273,7 @@
         745
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -3954,6 +4285,7 @@
       "name": "fabs",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -3965,6 +4297,7 @@
         508
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3977,6 +4310,7 @@
         521
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -3989,6 +4323,7 @@
         1988
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4002,6 +4337,7 @@
         1984
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -4013,6 +4349,7 @@
       "name": "feed-forward",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4022,6 +4359,7 @@
       "name": "fft",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4033,6 +4371,7 @@
         522
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -4045,6 +4384,7 @@
         1811
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4057,6 +4397,7 @@
         523
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -4069,6 +4410,7 @@
         1812
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -4080,6 +4422,7 @@
         1810
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4092,6 +4435,7 @@
         527
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -4103,6 +4447,7 @@
         1812
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -4114,6 +4459,7 @@
         524
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -4126,6 +4472,7 @@
         1753
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4138,6 +4485,7 @@
         1745
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4150,6 +4498,7 @@
         1743
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4160,6 +4509,7 @@
       "name": "file-delete",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4171,6 +4521,7 @@
         599
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4184,6 +4535,7 @@
         1754
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4196,6 +4548,7 @@
         1758
       ],
       "arity": 3,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4208,6 +4561,7 @@
         1752
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4220,6 +4574,7 @@
         1759
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4230,6 +4585,7 @@
       "name": "file-readable?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4241,6 +4597,7 @@
         1742
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4253,6 +4610,7 @@
         1740
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4265,6 +4623,7 @@
         1741
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4277,6 +4636,7 @@
         1755
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4287,6 +4647,7 @@
       "name": "file-writable?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4299,6 +4660,7 @@
         902
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -4311,6 +4673,7 @@
         166
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4325,6 +4688,7 @@
         420
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4338,6 +4702,7 @@
         26
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4349,6 +4714,7 @@
       "name": "floor-quotient",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4358,6 +4724,7 @@
       "name": "floor-remainder",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4367,6 +4734,7 @@
       "name": "floor/",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4376,6 +4744,7 @@
       "name": "flush-output-port",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4385,6 +4754,7 @@
       "name": "focal-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4396,6 +4766,7 @@
         626
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -4407,6 +4778,7 @@
         626
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -4418,6 +4790,7 @@
         1789
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -4429,6 +4802,7 @@
       "name": "format",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4440,6 +4814,7 @@
         1974
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4453,6 +4828,7 @@
         1976
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4466,6 +4842,7 @@
         817
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -4477,6 +4854,7 @@
         525
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -4489,6 +4867,7 @@
         1945
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4502,6 +4881,7 @@
         1942
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -4515,6 +4895,7 @@
         1944
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4528,6 +4909,7 @@
         1943
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -4541,6 +4923,7 @@
         625
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4553,6 +4936,7 @@
         627
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4565,6 +4949,7 @@
         1979
       ],
       "arity": 4,
+      "min_arity": 4,
       "backends": [
         "native",
         "vm",
@@ -4579,6 +4964,7 @@
         346
       ],
       "arity": 2,
+      "min_arity": null,
       "backends": [
         "native",
         "vm",
@@ -4590,6 +4976,7 @@
       "name": "gelu",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4601,6 +4988,7 @@
         2227
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -4613,6 +5001,7 @@
         847
       ],
       "arity": 4,
+      "min_arity": 4,
       "backends": [
         "vm"
       ],
@@ -4624,6 +5013,7 @@
         844
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -4635,6 +5025,7 @@
         845
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -4646,6 +5037,7 @@
         811
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -4657,6 +5049,7 @@
         851
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -4668,6 +5061,7 @@
         1715
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4681,6 +5075,7 @@
         598
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4694,6 +5089,7 @@
         1715
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4707,6 +5103,7 @@
         1710
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -4719,6 +5116,7 @@
         1756
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4731,6 +5129,7 @@
         1757
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4743,6 +5142,7 @@
         470
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -4755,6 +5155,7 @@
         440
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4767,6 +5168,7 @@
         471
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -4779,6 +5181,7 @@
         463
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4791,6 +5194,7 @@
         416
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4803,6 +5207,7 @@
         750
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -4815,6 +5220,7 @@
         819
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -4826,6 +5232,7 @@
         2021
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4839,6 +5246,7 @@
         2020
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4850,6 +5258,7 @@
       "name": "hard-sigmoid",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4859,6 +5268,7 @@
       "name": "hard-swish",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -4870,6 +5280,7 @@
         668
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4884,6 +5295,7 @@
         667
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4898,6 +5310,7 @@
         663
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -4913,6 +5326,7 @@
         664
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -4927,6 +5341,7 @@
         665
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -4941,6 +5356,7 @@
         661
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -4955,6 +5371,7 @@
         664
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -4969,6 +5386,7 @@
         662
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -4982,6 +5400,7 @@
         668
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -4994,6 +5413,7 @@
         664
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5006,6 +5426,7 @@
         663
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5018,6 +5439,7 @@
         664
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5030,6 +5452,7 @@
         665
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5040,6 +5463,7 @@
       "name": "hash-table-ref",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5051,6 +5475,7 @@
         661
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -5063,6 +5488,7 @@
         662
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -5075,6 +5501,7 @@
         667
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5087,6 +5514,7 @@
         666
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5099,6 +5527,7 @@
         667
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5112,6 +5541,7 @@
         670
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5126,6 +5556,7 @@
         666
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5139,6 +5570,7 @@
         752
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -5149,6 +5581,7 @@
       "name": "hinge-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5160,6 +5593,7 @@
         836
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -5171,6 +5605,7 @@
         1702
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -5183,6 +5618,7 @@
         1705
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -5195,6 +5631,7 @@
         2047
       ],
       "arity": 5,
+      "min_arity": 5,
       "backends": [
         "native",
         "vm",
@@ -5208,6 +5645,7 @@
         2044
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -5221,6 +5659,7 @@
         2046
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5234,6 +5673,7 @@
         2042
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5247,6 +5687,7 @@
         2043
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5260,6 +5701,7 @@
         2045
       ],
       "arity": 4,
+      "min_arity": 4,
       "backends": [
         "native",
         "vm",
@@ -5273,6 +5715,7 @@
         2065
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5286,6 +5729,7 @@
         2066
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -5297,6 +5741,7 @@
       "name": "huber-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5308,6 +5753,7 @@
         809
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -5319,6 +5765,7 @@
         810
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -5330,6 +5777,7 @@
         2100
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5342,6 +5790,7 @@
         2118
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5354,6 +5803,7 @@
         2117
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5366,6 +5816,7 @@
         2103
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5378,6 +5829,7 @@
         2110
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5390,6 +5842,7 @@
         2119
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5402,6 +5855,7 @@
         2111
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5414,6 +5868,7 @@
         2105
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5426,6 +5881,7 @@
         2108
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5438,6 +5894,7 @@
         2106
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5450,6 +5907,7 @@
         2107
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5462,6 +5920,7 @@
         2109
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5474,6 +5933,7 @@
         2104
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5486,6 +5946,7 @@
         2115
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5498,6 +5959,7 @@
         2113
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5510,6 +5972,7 @@
         2112
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5522,6 +5985,7 @@
         2116
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5534,6 +5998,7 @@
         2114
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5546,6 +6011,7 @@
         2102
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5556,6 +6022,7 @@
       "name": "ifft",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5567,6 +6034,7 @@
         303
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5580,6 +6048,7 @@
         1850
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5592,6 +6061,7 @@
         1853
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -5603,6 +6073,7 @@
         1852
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5615,6 +6086,7 @@
         1851
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -5627,6 +6099,7 @@
         192
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -5641,6 +6114,7 @@
         344
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5654,6 +6128,7 @@
         163
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5667,6 +6142,7 @@
         165
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5680,6 +6156,7 @@
         2019
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5691,6 +6168,7 @@
       "name": "inject-left",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5700,6 +6178,7 @@
       "name": "inject-right",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5709,6 +6188,7 @@
       "name": "input-port-open?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5720,6 +6200,7 @@
         728
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5733,6 +6214,7 @@
         2100
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5746,6 +6228,7 @@
         217
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -5759,6 +6242,7 @@
         1717
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5769,6 +6253,7 @@
       "name": "interaction-environment",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5780,6 +6265,7 @@
         837
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -5791,6 +6277,7 @@
         2025
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -5803,6 +6290,7 @@
         1783
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -5815,6 +6303,7 @@
         141
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -5827,6 +6316,7 @@
         751
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -5837,6 +6327,7 @@
       "name": "jiffies-per-second",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5848,6 +6339,7 @@
         2014
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -5860,6 +6352,7 @@
         2016
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -5872,6 +6365,7 @@
         2015
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -5882,6 +6376,7 @@
       "name": "kaiming-normal!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5891,6 +6386,7 @@
       "name": "kaiming-uniform!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5902,6 +6398,7 @@
         511
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -5914,6 +6411,7 @@
         1800
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -5926,6 +6424,7 @@
         1802
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -5937,6 +6436,7 @@
         1802
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -5946,6 +6446,7 @@
       "name": "kb-load",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -5957,6 +6458,7 @@
         512
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -5969,6 +6471,7 @@
         1801
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5981,6 +6484,7 @@
         1822
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -5993,6 +6497,7 @@
         510
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -6003,6 +6508,7 @@
       "name": "kl-div-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6012,6 +6518,7 @@
       "name": "label-smoothing-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6024,6 +6531,7 @@
         755
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -6034,6 +6542,7 @@
       "name": "last",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6045,6 +6554,7 @@
         188
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6058,6 +6568,7 @@
         475
       ],
       "arity": 4,
+      "min_arity": 4,
       "backends": [
         "vm",
         "native_llvm"
@@ -6071,6 +6582,7 @@
         347
       ],
       "arity": 2,
+      "min_arity": null,
       "backends": [
         "native",
         "vm",
@@ -6082,6 +6594,7 @@
       "name": "leaky-relu",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6091,6 +6604,7 @@
       "name": "lecun-normal!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6100,6 +6614,7 @@
       "name": "left?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6111,6 +6626,7 @@
         71
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6124,6 +6640,7 @@
         1987
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6137,6 +6654,7 @@
         1986
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6150,6 +6668,7 @@
         472
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -6160,6 +6679,7 @@
       "name": "linear-warmup-lr",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6171,6 +6691,7 @@
         746
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -6182,6 +6703,7 @@
       "name": "list",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6191,6 +6713,7 @@
       "name": "list*",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6203,6 +6726,7 @@
         223
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6217,6 +6741,7 @@
         227
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6230,6 +6755,7 @@
         186
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -6242,6 +6768,7 @@
         187
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -6254,6 +6781,7 @@
         189
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6267,6 +6795,7 @@
         1977
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -6280,6 +6809,7 @@
         24
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6291,6 +6821,7 @@
       "name": "log10",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6300,6 +6831,7 @@
       "name": "log2",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6311,6 +6843,7 @@
         501
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -6323,6 +6856,7 @@
         1994
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6336,6 +6870,7 @@
         1993
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6349,6 +6884,7 @@
         1990
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6362,6 +6898,7 @@
         1992
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6375,6 +6912,7 @@
         1991
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -6388,6 +6926,7 @@
         1995
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6399,6 +6938,7 @@
       "name": "mae-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6410,6 +6950,7 @@
         304
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6423,6 +6964,7 @@
         680
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -6435,6 +6977,7 @@
         2001
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -6447,6 +6990,7 @@
         2010
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -6459,6 +7003,7 @@
         2010
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -6469,6 +7014,7 @@
       "name": "make-dataloader",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6478,6 +7024,7 @@
       "name": "make-directory",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6490,6 +7037,7 @@
         370
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -6502,6 +7050,7 @@
         804
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -6514,6 +7063,7 @@
         1997
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -6526,6 +7076,7 @@
         2220
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6539,6 +7090,7 @@
         507
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native"
       ],
@@ -6550,6 +7102,7 @@
         520
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native"
       ],
@@ -6562,6 +7115,7 @@
         660
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -6575,6 +7129,7 @@
         805
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -6587,6 +7142,7 @@
         2024
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -6599,6 +7155,7 @@
         509
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -6611,6 +7168,7 @@
         1985
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6624,6 +7182,7 @@
         1989
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6637,6 +7196,7 @@
         2006
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -6649,6 +7209,7 @@
         1983
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -6662,6 +7223,7 @@
         301
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6673,6 +7235,7 @@
       "name": "make-prng",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6684,6 +7247,7 @@
         807
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -6693,6 +7257,7 @@
       "name": "make-rational",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6704,6 +7269,7 @@
         300
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6717,6 +7283,7 @@
         860
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -6728,6 +7295,7 @@
         806
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -6740,6 +7308,7 @@
         226
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -6752,6 +7321,7 @@
         505
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -6764,6 +7334,7 @@
         1761
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6777,6 +7348,7 @@
         1760
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -6790,6 +7362,7 @@
         410
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -6803,6 +7376,7 @@
         2022
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -6815,6 +7389,7 @@
         218
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -6827,6 +7402,7 @@
         540
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -6839,6 +7415,7 @@
         808
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -6850,6 +7427,7 @@
         859
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -6861,6 +7439,7 @@
         858
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -6872,6 +7451,7 @@
         811
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -6883,6 +7463,7 @@
         809
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -6894,6 +7475,7 @@
         857
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -6906,6 +7488,7 @@
         854
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -6917,6 +7500,7 @@
         810
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -6928,6 +7512,7 @@
         813
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -6937,6 +7522,7 @@
       "name": "map",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6948,6 +7534,7 @@
         440
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -6959,6 +7546,7 @@
       "name": "matrix-to-string",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6970,6 +7558,7 @@
         34
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "native_llvm"
@@ -6980,6 +7569,7 @@
       "name": "max-pool2d",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -6991,6 +7581,7 @@
         137
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -7001,6 +7592,7 @@
       "name": "memory-fence",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7012,6 +7604,7 @@
         139
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -7023,6 +7616,7 @@
         829
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -7034,6 +7628,7 @@
         33
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "native_llvm"
@@ -7044,6 +7639,7 @@
       "name": "mish",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7055,6 +7651,7 @@
         1744
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7067,6 +7664,7 @@
         1751
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7079,6 +7677,7 @@
         1750
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7091,6 +7690,7 @@
         814
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -7102,6 +7702,7 @@
         815
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -7111,6 +7712,7 @@
       "name": "mod",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7122,6 +7724,7 @@
         801
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7135,6 +7738,7 @@
         800
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -7148,6 +7752,7 @@
         36
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -7161,6 +7766,7 @@
         1950
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -7174,6 +7780,7 @@
         459
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "native_llvm"
@@ -7186,6 +7793,7 @@
         144
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -7196,6 +7804,7 @@
       "name": "multi-head-attention",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7207,6 +7816,7 @@
         2007
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -7219,6 +7829,7 @@
         2008
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -7231,6 +7842,7 @@
         164
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7244,6 +7856,7 @@
         41
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7257,6 +7870,7 @@
         60
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -7268,6 +7882,7 @@
       "name": "norm",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7280,6 +7895,7 @@
         235
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7291,6 +7907,7 @@
       "name": "null-environment",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7300,6 +7917,7 @@
       "name": "null-ptr",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7312,6 +7930,7 @@
         203
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7325,6 +7944,7 @@
         51
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -7338,6 +7958,7 @@
         206
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7352,6 +7973,7 @@
         346
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7365,6 +7987,7 @@
         42
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7378,6 +8001,7 @@
         2000
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -7390,6 +8014,7 @@
         1998
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -7402,6 +8027,7 @@
         1999
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -7414,6 +8040,7 @@
         418
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7425,6 +8052,7 @@
       "name": "onnx-export-tensor",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7436,6 +8064,7 @@
         2068
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7449,6 +8078,7 @@
         2069
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7462,6 +8092,7 @@
         580
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7475,6 +8106,7 @@
         596
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7488,6 +8120,7 @@
         581
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7499,6 +8132,7 @@
       "name": "open-output-file-append",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7510,6 +8144,7 @@
         597
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -7523,6 +8158,7 @@
         1701
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -7535,6 +8171,7 @@
         1700
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -7545,6 +8182,7 @@
       "name": "outer",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7554,6 +8192,7 @@
       "name": "output-port-open?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7565,6 +8204,7 @@
         729
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7576,6 +8216,7 @@
       "name": "pad",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7585,6 +8226,7 @@
       "name": "padding-mask",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7597,6 +8239,7 @@
         204
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7608,6 +8251,7 @@
       "name": "parallel-execute",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7619,6 +8263,7 @@
         621
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -7631,6 +8276,7 @@
         622
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -7643,6 +8289,7 @@
         623
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -7655,6 +8302,7 @@
         620
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -7667,6 +8315,7 @@
         812
       ],
       "arity": 4,
+      "min_arity": 4,
       "backends": [
         "vm"
       ],
@@ -7678,6 +8327,7 @@
         701
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -7689,6 +8339,7 @@
         704
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7701,6 +8352,7 @@
         1975
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7714,6 +8366,7 @@
         1722
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7726,6 +8379,7 @@
         1721
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7738,6 +8392,7 @@
         1723
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7750,6 +8405,7 @@
         1724
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7762,6 +8418,7 @@
         1720
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -7774,6 +8431,7 @@
         1725
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7786,6 +8444,7 @@
         1727
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -7798,6 +8457,7 @@
         1728
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -7808,6 +8468,7 @@
       "name": "peek-char",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7817,6 +8478,7 @@
       "name": "peek-u8",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7828,6 +8490,7 @@
         816
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -7839,6 +8502,7 @@
         1783
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -7849,6 +8513,7 @@
       "name": "poll-fd",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7860,6 +8525,7 @@
         2202
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -7872,6 +8538,7 @@
         730
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7883,6 +8550,7 @@
       "name": "positional-encoding",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7894,6 +8562,7 @@
         40
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7907,6 +8576,7 @@
         32
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -7920,6 +8590,7 @@
         1952
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7931,6 +8602,7 @@
       "name": "prng-random",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7940,6 +8612,7 @@
       "name": "prng-random-integer",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7949,6 +8622,7 @@
       "name": "prng?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7958,6 +8632,7 @@
       "name": "procedure-arity",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -7970,6 +8645,7 @@
         209
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -7983,6 +8659,7 @@
         1782
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -7996,6 +8673,7 @@
         1786
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8009,6 +8687,7 @@
         1784
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -8022,6 +8701,7 @@
         1788
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8035,6 +8715,7 @@
         1785
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8048,6 +8729,7 @@
         1780
       ],
       "arity": 3,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8061,6 +8743,7 @@
         1780
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -8072,6 +8755,7 @@
         1803
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -8083,6 +8767,7 @@
         1803
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -8094,6 +8779,7 @@
         1787
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8107,6 +8793,7 @@
         1780
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -8119,6 +8806,7 @@
         1781
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8130,6 +8818,7 @@
       "name": "promise?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8139,6 +8828,7 @@
       "name": "ptr->string",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8148,6 +8838,7 @@
       "name": "ptr->string-n",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8157,6 +8848,7 @@
       "name": "ptr->usize",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8166,6 +8858,7 @@
       "name": "ptr-add",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8177,6 +8870,7 @@
         838
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -8188,6 +8882,7 @@
         1860
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -8200,6 +8895,7 @@
         1861
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -8212,6 +8908,7 @@
         1862
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -8224,6 +8921,7 @@
         828
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -8235,6 +8933,7 @@
         38
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8246,6 +8945,7 @@
       "name": "rand",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8255,6 +8955,7 @@
       "name": "randint",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8264,6 +8965,7 @@
       "name": "randn",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8275,6 +8977,7 @@
         1863
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -8288,6 +8991,7 @@
         1698
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8301,6 +9005,7 @@
         349
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8314,6 +9019,7 @@
         588
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "native_llvm"
@@ -8326,6 +9032,7 @@
         2072
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8339,6 +9046,7 @@
         583
       ],
       "arity": 1,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -8350,6 +9058,7 @@
       "name": "read-file",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8361,6 +9070,7 @@
         585
       ],
       "arity": 1,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -8372,6 +9082,7 @@
       "name": "read-string",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8383,6 +9094,7 @@
         2070
       ],
       "arity": 1,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -8396,6 +9108,7 @@
         302
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8410,6 +9123,7 @@
         1697
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8423,6 +9137,7 @@
         1726
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -8433,6 +9148,7 @@
       "name": "reduce",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8444,6 +9160,7 @@
         1966
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8457,6 +9174,7 @@
         1967
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8470,6 +9188,7 @@
         1968
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8483,6 +9202,7 @@
         1970
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8496,6 +9216,7 @@
         1969
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8509,6 +9230,7 @@
         1971
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8520,6 +9242,7 @@
       "name": "region-close",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8529,6 +9252,7 @@
       "name": "region-open",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8540,6 +9264,7 @@
         2212
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -8552,6 +9277,7 @@
         462
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8565,6 +9291,7 @@
         37
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8576,6 +9303,7 @@
       "name": "remove",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8585,6 +9313,7 @@
       "name": "remq",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8594,6 +9323,7 @@
       "name": "remv",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8606,6 +9336,7 @@
         415
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8619,6 +9350,7 @@
         842
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -8630,6 +9362,7 @@
         136
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -8642,6 +9375,7 @@
         1840
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -8653,6 +9387,7 @@
         832
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -8664,6 +9399,7 @@
         831
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -8675,6 +9411,7 @@
         840
       ],
       "arity": 6,
+      "min_arity": 6,
       "backends": [
         "vm"
       ],
@@ -8686,6 +9423,7 @@
         861
       ],
       "arity": 7,
+      "min_arity": 7,
       "backends": [
         "vm"
       ],
@@ -8697,6 +9435,7 @@
         841
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -8708,6 +9447,7 @@
         839
       ],
       "arity": 4,
+      "min_arity": 4,
       "backends": [
         "vm"
       ],
@@ -8717,6 +9457,7 @@
       "name": "right?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8726,6 +9467,7 @@
       "name": "rmsprop-step",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8735,6 +9477,7 @@
       "name": "rotary-embedding",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8746,6 +9489,7 @@
         28
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8759,6 +9503,7 @@
         477
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -8769,6 +9514,7 @@
       "name": "scheme-report-environment",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8780,6 +9526,7 @@
         826
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -8791,6 +9538,7 @@
         827
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -8802,6 +9550,7 @@
         833
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -8811,6 +9560,7 @@
       "name": "selu",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8822,6 +9572,7 @@
         1981
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8835,6 +9586,7 @@
         1980
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8848,6 +9600,7 @@
         1982
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8859,6 +9612,7 @@
       "name": "set-car!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8868,6 +9622,7 @@
       "name": "set-cdr!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8879,6 +9634,7 @@
         1704
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -8891,6 +9647,7 @@
         850
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -8900,6 +9657,7 @@
       "name": "set-random-seed!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8911,6 +9669,7 @@
         1712
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -8922,6 +9681,7 @@
       "name": "sgd-step",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -8933,6 +9693,7 @@
         1965
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8946,6 +9707,7 @@
         1770
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -8958,6 +9720,7 @@
         1771
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -8969,6 +9732,7 @@
         464
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -8982,6 +9746,7 @@
         743
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -8994,6 +9759,7 @@
         1795
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -9006,6 +9772,7 @@
         1798
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm"
@@ -9018,6 +9785,7 @@
         1797
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -9030,6 +9798,7 @@
         1794
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -9042,6 +9811,7 @@
         1796
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -9052,6 +9822,7 @@
       "name": "silu",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9063,6 +9834,7 @@
         20
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9076,6 +9848,7 @@
         721
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9087,6 +9860,7 @@
       "name": "sleep",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9098,6 +9872,7 @@
         1711
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -9110,6 +9885,7 @@
         820
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -9119,6 +9895,7 @@
       "name": "slice",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9128,6 +9905,7 @@
       "name": "smooth-l1-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9139,6 +9917,7 @@
         824
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -9150,6 +9929,7 @@
         825
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -9161,6 +9941,7 @@
         1793
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9174,6 +9955,7 @@
         1792
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -9187,6 +9969,7 @@
         1791
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -9200,6 +9983,7 @@
         463
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9211,6 +9995,7 @@
       "name": "softplus",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9222,6 +10007,7 @@
         230
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native"
       ],
@@ -9233,6 +10019,7 @@
         821
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -9244,6 +10031,7 @@
         821
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -9255,6 +10043,7 @@
         822
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -9266,6 +10055,7 @@
         822
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -9277,6 +10067,7 @@
         823
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -9286,6 +10077,7 @@
       "name": "split",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9295,6 +10087,7 @@
       "name": "split-at",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9306,6 +10099,7 @@
         25
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9317,6 +10111,7 @@
       "name": "square",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9326,6 +10121,7 @@
       "name": "squeeze",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9337,6 +10133,7 @@
         1864
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -9347,6 +10144,7 @@
       "name": "stack",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9356,6 +10154,7 @@
       "name": "step-decay-lr",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9365,6 +10164,7 @@
       "name": "string",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9376,6 +10176,7 @@
         2101
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -9389,6 +10190,7 @@
         222
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9403,6 +10205,7 @@
         215
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9416,6 +10219,7 @@
         185
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9429,6 +10233,7 @@
         689
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -9441,6 +10246,7 @@
         54
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "native_llvm"
@@ -9453,6 +10259,7 @@
         571
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -9463,6 +10270,7 @@
       "name": "string-ci<=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9472,6 +10280,7 @@
       "name": "string-ci<?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9483,6 +10292,7 @@
         562
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -9493,6 +10303,7 @@
       "name": "string-ci>=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9502,6 +10313,7 @@
       "name": "string-ci>?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9514,6 +10326,7 @@
         555
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -9524,6 +10337,7 @@
       "name": "string-contains?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9536,6 +10350,7 @@
         566
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9547,6 +10362,7 @@
       "name": "string-copy!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9558,6 +10374,7 @@
         1947
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9572,6 +10389,7 @@
         558
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9585,6 +10403,7 @@
         1956
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -9598,6 +10417,7 @@
         556
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -9608,6 +10428,7 @@
       "name": "string-foldcase",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9617,6 +10438,7 @@
       "name": "string-for-each",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9626,6 +10448,7 @@
       "name": "string-index",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9637,6 +10460,7 @@
         1957
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -9651,6 +10475,7 @@
         909
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -9664,6 +10489,7 @@
         550
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9675,6 +10501,7 @@
       "name": "string-map",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9686,6 +10513,7 @@
         1958
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -9699,6 +10527,7 @@
         1959
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -9710,6 +10539,7 @@
       "name": "string-port?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9722,6 +10552,7 @@
         551
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -9736,6 +10567,7 @@
         906
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -9749,6 +10581,7 @@
         905
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -9759,6 +10592,7 @@
       "name": "string-set!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9771,6 +10605,7 @@
         908
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -9785,6 +10620,7 @@
         907
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -9797,6 +10633,7 @@
         1948
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -9811,6 +10648,7 @@
         557
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9822,6 +10660,7 @@
       "name": "string<=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9833,6 +10672,7 @@
         561
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -9846,6 +10686,7 @@
         560
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -9857,6 +10698,7 @@
       "name": "string>=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9866,6 +10708,7 @@
       "name": "string>?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9878,6 +10721,7 @@
         207
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9891,6 +10735,7 @@
         143
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -9903,6 +10748,7 @@
         506
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -9916,6 +10762,7 @@
         553
       ],
       "arity": 3,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -9929,6 +10776,7 @@
         184
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9940,6 +10788,7 @@
       "name": "symbol=?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9951,6 +10800,7 @@
         160
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -9964,6 +10814,7 @@
         1746
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -9976,6 +10827,7 @@
         1747
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -9986,6 +10838,7 @@
       "name": "system",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -9998,6 +10851,7 @@
         903
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -10010,6 +10864,7 @@
         22
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10023,6 +10878,7 @@
         722
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10036,6 +10892,7 @@
         757
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -10047,6 +10904,7 @@
         1951
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10061,6 +10919,7 @@
         474
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -10071,6 +10930,7 @@
       "name": "tensor->vector",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10082,6 +10942,7 @@
         451
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10094,6 +10955,7 @@
         441
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10106,6 +10968,7 @@
         478
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10116,6 +10979,7 @@
       "name": "tensor-argmax",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10125,6 +10989,7 @@
       "name": "tensor-argmin",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10136,6 +11001,7 @@
         422
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10146,6 +11012,7 @@
       "name": "tensor-cholesky",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10155,6 +11022,7 @@
       "name": "tensor-corrcoef",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10166,6 +11034,7 @@
         461
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10176,6 +11045,7 @@
       "name": "tensor-cov",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10187,6 +11057,7 @@
         414
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10197,6 +11068,7 @@
       "name": "tensor-det",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10206,6 +11078,7 @@
       "name": "tensor-disk-fill!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10217,6 +11090,7 @@
         444
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10229,6 +11103,7 @@
         449
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -10242,6 +11117,7 @@
         421
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10254,6 +11130,7 @@
         453
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10266,6 +11143,7 @@
         411
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -10277,6 +11155,7 @@
       "name": "tensor-inverse",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10286,6 +11165,7 @@
       "name": "tensor-length",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10297,6 +11177,7 @@
         803
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10310,6 +11191,7 @@
         454
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10320,6 +11202,7 @@
       "name": "tensor-lu",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10331,6 +11214,7 @@
         440
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10341,6 +11225,7 @@
       "name": "tensor-max",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10352,6 +11237,7 @@
         446
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10364,6 +11250,7 @@
         446
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -10374,6 +11261,7 @@
       "name": "tensor-min",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10385,6 +11273,7 @@
         447
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10397,6 +11286,7 @@
         443
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10409,6 +11299,7 @@
         450
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10421,6 +11312,7 @@
         445
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10431,6 +11323,7 @@
       "name": "tensor-qr",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10440,6 +11333,7 @@
       "name": "tensor-rect-fill!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10449,6 +11343,7 @@
       "name": "tensor-reduce",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10458,6 +11353,7 @@
       "name": "tensor-reduce-all",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10469,6 +11365,7 @@
         411
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -10483,6 +11380,7 @@
         415
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -10496,6 +11394,7 @@
         802
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -10509,6 +11408,7 @@
         456
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10519,6 +11419,7 @@
       "name": "tensor-set",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10530,6 +11431,7 @@
         412
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -10542,6 +11444,7 @@
         413
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10555,6 +11458,7 @@
         455
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10565,6 +11469,7 @@
       "name": "tensor-solve",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10576,6 +11481,7 @@
         452
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -10586,6 +11492,7 @@
       "name": "tensor-std",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10597,6 +11504,7 @@
         442
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -10609,6 +11517,7 @@
         445
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -10619,6 +11528,7 @@
       "name": "tensor-svd",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10628,6 +11538,7 @@
       "name": "tensor-token-estimate",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10640,6 +11551,7 @@
         416
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10651,6 +11563,7 @@
       "name": "tensor-var",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10663,6 +11576,7 @@
         1699
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10676,6 +11590,7 @@
         1941
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10689,6 +11604,7 @@
         1938
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10702,6 +11618,7 @@
         1937
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10715,6 +11632,7 @@
         603
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm"
       ],
@@ -10726,6 +11644,7 @@
         1940
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10739,6 +11658,7 @@
         1936
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10752,6 +11672,7 @@
         1933
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10765,6 +11686,7 @@
         1935
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10778,6 +11700,7 @@
         1932
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10791,6 +11714,7 @@
         1939
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -10804,6 +11728,7 @@
         1934
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10817,6 +11742,7 @@
         1931
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -10830,6 +11756,7 @@
         1930
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -10841,6 +11768,7 @@
       "name": "textual-port?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10852,6 +11780,7 @@
         628
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -10864,6 +11793,7 @@
         628
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -10874,6 +11804,7 @@
       "name": "thread-pool-stats",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10883,6 +11814,7 @@
       "name": "tile",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10892,6 +11824,7 @@
       "name": "time",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10903,6 +11836,7 @@
         2023
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -10915,6 +11849,7 @@
         2026
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -10925,6 +11860,7 @@
       "name": "trace",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10934,6 +11870,7 @@
       "name": "train-test-split",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10945,6 +11882,7 @@
         853
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm"
       ],
@@ -10957,6 +11895,7 @@
         416
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10968,6 +11907,7 @@
       "name": "triplet-loss",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10977,6 +11917,7 @@
       "name": "trunc",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -10988,6 +11929,7 @@
         190
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -10999,6 +11941,7 @@
       "name": "truncate-quotient",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11008,6 +11951,7 @@
       "name": "truncate-remainder",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11017,6 +11961,7 @@
       "name": "truncate/",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11028,6 +11973,7 @@
         2063
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -11041,6 +11987,7 @@
         2059
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11054,6 +12001,7 @@
         2058
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11067,6 +12015,7 @@
         2057
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11080,6 +12029,7 @@
         2055
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11093,6 +12043,7 @@
         2054
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11106,6 +12057,7 @@
         2053
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11119,6 +12071,7 @@
         2062
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11132,6 +12085,7 @@
         2061
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -11145,6 +12099,7 @@
         2060
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11158,6 +12113,7 @@
         2056
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11171,6 +12127,7 @@
         2064
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11184,6 +12141,7 @@
         740
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11195,6 +12153,7 @@
       "name": "u8-ready?",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11206,6 +12165,7 @@
         502
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -11218,6 +12178,7 @@
         1790
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11231,6 +12192,7 @@
         1713
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11242,6 +12204,7 @@
       "name": "unsqueeze",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11253,6 +12216,7 @@
         1955
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11266,6 +12230,7 @@
         1954
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11279,6 +12244,7 @@
         1960
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11292,6 +12258,7 @@
         1706
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "vm",
         "native_llvm"
@@ -11302,6 +12269,7 @@
       "name": "usize->ptr",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11313,6 +12281,7 @@
         688
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -11325,6 +12294,7 @@
         1963
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -11336,6 +12306,7 @@
       "name": "vector",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11347,6 +12318,7 @@
         140
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11358,6 +12330,7 @@
       "name": "vector->tensor",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11367,6 +12340,7 @@
       "name": "vector-append",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11376,6 +12350,7 @@
       "name": "vector-copy",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11385,6 +12360,7 @@
       "name": "vector-copy!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11394,6 +12370,7 @@
       "name": "vector-fill!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11403,6 +12380,7 @@
       "name": "vector-for-each",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11414,6 +12392,7 @@
         221
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm",
         "native_llvm"
@@ -11424,6 +12403,7 @@
       "name": "vector-map",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11435,6 +12415,7 @@
         219
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm",
         "native_llvm"
@@ -11447,6 +12428,7 @@
         220
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "vm",
         "native_llvm"
@@ -11457,6 +12439,7 @@
       "name": "vector-to-string",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11468,6 +12451,7 @@
         843
       ],
       "arity": 4,
+      "min_arity": 4,
       "backends": [
         "vm"
       ],
@@ -11480,6 +12464,7 @@
         210
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11493,6 +12478,7 @@
         238
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -11504,6 +12490,7 @@
       "name": "volatile-load",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11513,6 +12500,7 @@
       "name": "volatile-store!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11522,6 +12510,7 @@
       "name": "vqe-energy-primitive",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11534,6 +12523,7 @@
         219
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11547,6 +12537,7 @@
         503
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -11559,6 +12550,7 @@
         2052
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11572,6 +12564,7 @@
         2048
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11585,6 +12578,7 @@
         2051
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11598,6 +12592,7 @@
         2049
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11611,6 +12606,7 @@
         2050
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11624,6 +12620,7 @@
         834
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -11633,6 +12630,7 @@
       "name": "with-exception-handler",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11642,6 +12640,7 @@
       "name": "with-input-from-file",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11653,6 +12652,7 @@
         2009
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm"
@@ -11663,6 +12663,7 @@
       "name": "with-output-to-file",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11674,6 +12675,7 @@
         541
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -11686,6 +12688,7 @@
         241
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -11698,6 +12701,7 @@
         2073
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11711,6 +12715,7 @@
         586
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11722,6 +12727,7 @@
       "name": "write-file",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11733,6 +12739,7 @@
         726
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "native_llvm"
@@ -11743,6 +12750,7 @@
       "name": "write-shared",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11752,6 +12760,7 @@
       "name": "write-simple",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11763,6 +12772,7 @@
         587
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11776,6 +12786,7 @@
         2071
       ],
       "arity": 2,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11789,6 +12800,7 @@
         544
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -11800,6 +12812,7 @@
         546
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -11811,6 +12824,7 @@
         547
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "vm"
       ],
@@ -11822,6 +12836,7 @@
         542
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm"
@@ -11834,6 +12849,7 @@
         545
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "vm"
       ],
@@ -11845,6 +12861,7 @@
         543
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm"
@@ -11855,6 +12872,7 @@
       "name": "xavier-normal!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11864,6 +12882,7 @@
       "name": "xavier-uniform!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11875,6 +12894,7 @@
         2038
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11888,6 +12908,7 @@
         2039
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -11901,6 +12922,7 @@
         2036
       ],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "native",
         "vm",
@@ -11914,6 +12936,7 @@
         2041
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11927,6 +12950,7 @@
         2040
       ],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "native",
         "vm",
@@ -11940,6 +12964,7 @@
         2037
       ],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "native",
         "vm",
@@ -11951,6 +12976,7 @@
       "name": "zero-grad!",
       "ids": [],
       "arity": null,
+      "min_arity": null,
       "backends": [
         "native_llvm"
       ],
@@ -11962,6 +12988,7 @@
         44
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11975,6 +13002,7 @@
         417
       ],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "native",
         "vm",
@@ -11986,6 +13014,7 @@
       "name": "apply-cnot",
       "ids": [],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "agent_ffi"
       ],
@@ -11996,6 +13025,7 @@
       "name": "apply-hadamard",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12006,6 +13036,7 @@
       "name": "apply-pauli-x",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12016,6 +13047,7 @@
       "name": "apply-pauli-y",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12026,6 +13058,7 @@
       "name": "apply-pauli-z",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12036,6 +13069,7 @@
       "name": "apply-rx",
       "ids": [],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "agent_ffi"
       ],
@@ -12046,6 +13080,7 @@
       "name": "apply-ry",
       "ids": [],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "agent_ffi"
       ],
@@ -12056,6 +13091,7 @@
       "name": "apply-rz",
       "ids": [],
       "arity": 3,
+      "min_arity": 3,
       "backends": [
         "agent_ffi"
       ],
@@ -12066,6 +13102,7 @@
       "name": "bell-chsh",
       "ids": [],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "agent_ffi"
       ],
@@ -12076,6 +13113,7 @@
       "name": "expectation-z",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12086,6 +13124,7 @@
       "name": "hamiltonian-exact-ground-energy",
       "ids": [],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "agent_ffi"
       ],
@@ -12096,6 +13135,7 @@
       "name": "make-h2-hamiltonian",
       "ids": [],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "agent_ffi"
       ],
@@ -12106,6 +13146,7 @@
       "name": "make-h2o-hamiltonian",
       "ids": [],
       "arity": 0,
+      "min_arity": 0,
       "backends": [
         "agent_ffi"
       ],
@@ -12116,6 +13157,7 @@
       "name": "make-lih-hamiltonian",
       "ids": [],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "agent_ffi"
       ],
@@ -12126,6 +13168,7 @@
       "name": "make-quantum-state",
       "ids": [],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "agent_ffi"
       ],
@@ -12136,6 +13179,7 @@
       "name": "measure",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12146,6 +13190,7 @@
       "name": "mlkem-decaps",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12156,6 +13201,7 @@
       "name": "mlkem-encaps",
       "ids": [],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "agent_ffi"
       ],
@@ -12166,6 +13212,7 @@
       "name": "mlkem-keygen",
       "ids": [],
       "arity": 1,
+      "min_arity": 1,
       "backends": [
         "agent_ffi"
       ],
@@ -12176,6 +13223,7 @@
       "name": "vqe-energy",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12186,6 +13234,7 @@
       "name": "vqe-gradient",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],
@@ -12196,6 +13245,7 @@
       "name": "vqe-optimize",
       "ids": [],
       "arity": 2,
+      "min_arity": 2,
       "backends": [
         "agent_ffi"
       ],

--- a/tests/diagnostics/arity_below_documented_minimum/expected.json
+++ b/tests/diagnostics/arity_below_documented_minimum/expected.json
@@ -1,0 +1,10 @@
+{
+  "description": "A call below a builtin's DOCUMENTED MINIMUM is refused with the canonical arity sentence quoting that minimum — 'expects 2 arguments', not the opcode's three operands. Both engines derive the number from the one BUILTINS[] column (eshkol_builtin_min_arity), so the bytecode VM prints the same sentence for the same call and accepts the two-argument form that native has always accepted.",
+  "compile": "fail",
+  "diagnostics": [
+    {
+      "contains": "Arity mismatch: substring expects 2 arguments but got 1",
+      "span": {"file": "input.esk", "line": 17, "col": 11}
+    }
+  ]
+}

--- a/tests/diagnostics/arity_below_documented_minimum/input.esk
+++ b/tests/diagnostics/arity_below_documented_minimum/input.esk
@@ -1,0 +1,18 @@
+;; Diagnostic corpus case: a call BELOW a builtin's documented minimum.
+;;
+;; `substring` is documented `(substring string start [end])` and its native
+;; lowering refuses anything shorter than two arguments — so `(substring "x")`
+;; is a wrong-arity call, and it must be refused with the canonical sentence
+;; naming the MINIMUM, not the opcode's operand count.
+;;
+;; The distinction is the whole of this fix. The bytecode VM used to refuse
+;; `(substring "hello" 1)` too, because its under-arity check read
+;; `BUILTINS[].arity` — the number of operands the opcode loads (3) — rather
+;; than the caller's obligation (2). Both engines now read the minimum from
+;; eshkol_builtin_min_arity(), so this diagnostic says "expects 2 arguments",
+;; the two-argument call compiles, and the sentence is byte-identical on the
+;; bytecode VM.
+;; See inc/eshkol/core/arity_contract.h and scripts/gen_builtin_min_arity.py.
+
+(display (substring "x"))
+(newline)

--- a/tests/vm_parity/corpus/82_builtin_optional_argument_arity.esk
+++ b/tests/vm_parity/corpus/82_builtin_optional_argument_arity.esk
@@ -1,0 +1,89 @@
+; Every builtin with a DOCUMENTED OPTIONAL parameter, called at its minimum
+; documented argument count and at its full one, on both engines.
+;
+; The bytecode VM used to refuse the minimum call. `BUILTINS[].arity` is the
+; number of operands the opcode loads, not the number of arguments a caller
+; must supply, and the VM's under-arity check fell back to it for every row
+; that left `min_arity` unset — so `(substring "hello" 1)`, `(make-vector 3)`
+; and `(read-line)` compiled and ran natively and were refused by the VM with
+; "Arity mismatch: substring expects 3 arguments but got 2". The minima are now
+; derived (scripts/gen_builtin_min_arity.py) and the omitted operands are
+; supplied at the call site as ESHKOL_ABSENT_ARG, which each native op reads as
+; "apply the documented default".
+;
+; The four READERS whose minimum call takes no port are exercised as
+; DEFINITIONS that are never applied. Their contract here is acceptance — the
+; VM refused to COMPILE them — and calling one would read this harness's stdin,
+; which is a terminal.
+
+; ── substring: (substring s start [end]) ─────────────────────────────────
+(display (substring "hello" 1))       (newline)
+(display (substring "hello" 1 3))     (newline)
+
+; ── make-vector: (make-vector k [fill]) ──────────────────────────────────
+(display (make-vector 3))             (newline)
+(display (make-vector 3 7))           (newline)
+
+; ── make-string: (make-string k [char]) ──────────────────────────────────
+(display (string-length (make-string 4)))          (newline)
+(display (make-string 4 #\z))                      (newline)
+
+; ── make-bytevector: (make-bytevector k [byte]) ──────────────────────────
+(display (bytevector-length (make-bytevector 4)))  (newline)
+(display (bytevector-u8-ref (make-bytevector 4 255) 2))  (newline)
+
+; ── append: (append [lst [lst]]) — R7RS 6.4, (append) is the empty list ───
+(display (append))                     (newline)
+(display (append (list 1 2)))          (newline)
+(display (append (list 1 2) (list 3))) (newline)
+
+; ── gcd / lcm: variadic in the native lowering, so every operand may be
+;    omitted. R7RS 6.2.6 makes (gcd) 0 and (lcm) 1. These rows declare
+;    themselves variadic and made no minimum claim, so the VM's COMPILE-time
+;    check never fired for them — and the call still died at RUNTIME, where
+;    the closure wanted both operands. The omitted ones are the fold identity.
+(display (gcd))                        (newline)
+(display (gcd 12))                     (newline)
+(display (gcd 12 18))                  (newline)
+(display (lcm))                        (newline)
+(display (lcm 4))                      (newline)
+(display (lcm 4 6))                    (newline)
+
+; ── bytevector-append: (bytevector-append [bv [bv]]) ─────────────────────
+(display (bytevector-length (bytevector-append)))                       (newline)
+(display (bytevector-length (bytevector-append (make-bytevector 2 1))))  (newline)
+(display (bytevector-length
+           (bytevector-append (make-bytevector 2 1) (make-bytevector 3 2)))) (newline)
+
+; ── hash-ref: (hash-ref table key [default]) ─────────────────────────────
+(define table (make-hash-table))
+(hash-set! table 1 10)
+(display (hash-ref table 1))          (newline)
+(display (hash-ref table 1 0))        (newline)
+
+; ── make-tensor: (make-tensor shape [fill]) ──────────────────────────────
+(display (tensor-shape (make-tensor (list 2 2) 1.0)))  (newline)
+
+; ── write-string: (write-string s [port]) ────────────────────────────────
+(write-string "write-string/1")       (newline)
+(define sink (open-output-string))
+(write-string "to-port" sink)
+(display (get-output-string sink))     (newline)
+
+; ── write-u8 / write-bytevector: (write-u8 byte [port]) ──────────────────
+(write-u8 65)
+(write-bytevector (make-bytevector 1 66))
+(newline)
+
+; ── read-char / read-line: (read-char [port]) ────────────────────────────
+(display (char->integer (read-char (open-input-string "A"))))  (newline)
+(display (read-line (open-input-string "one")))                (newline)
+(display (eof-object? (read-char (open-input-string ""))))     (newline)
+
+; The minimum-arity forms of the four readers: accepted by both engines, which
+; is what compiling this file proves. Never applied — see the header.
+(define (min-arity-read-char) (read-char))
+(define (min-arity-read-line) (read-line))
+(define (min-arity-read-u8) (read-u8))
+(define (min-arity-read-bytevector) (read-bytevector 1))
+(display "readers accepted at minimum arity")                  (newline)


### PR DESCRIPTION
## The defect

The bytecode VM refused calls that omit an argument the caller is entitled to omit, and that native accepts:

```
(substring "hello" 1)     native  ello
                          VM      Arity mismatch: substring expects 3 arguments but got 2
(append)                  native  ()
                          VM      Arity mismatch: append expects 1 argument but got 0
(gcd)                     native  0
                          VM      arity mismatch: expected 2 arguments, got 0   ← at RUNTIME
```

and the same for `(make-vector 3)`, `(make-string 3)`, `(read-line)`, `(bytevector-append)` and `(hash-ref table key)`.

`arity` in `BUILTINS[]` is the number of operands `emit_builtin_preamble()` loads into the opcode — the **shape** of the call — and the VM's under-arity check falls back to it whenever a row leaves `min_arity` at 0. That was **739 rows out of 742**.

## Size of the class

A probe over all 742 rows × every argument count, on both engines, found **394 builtins where native accepts a shorter call than the VM**. The derivation separates them:

* **19** have an argument the caller may legally omit — *this* defect. Sixteen with a documented optional parameter (`substring`, `make-vector`, `make-string`, `make-bytevector`, `make-tensor`, `hash-ref`, `read-char`, `read-line`, `read-u8`, `read-bytevector`, `write-string`, `write-u8`, `write-bytevector`, `file-mmap`, `process-spawn`, and `append`), plus the three R7RS variadic **folds** whose zero-argument form is the identity (`append`, `gcd`, `lcm`, `bytevector-append`).
* **339** where native simply has no arity guard and answers `packNull()` — `(char-upcase)` "succeeds" with `()` on native. That is native's own permissiveness; the VM's refusal is the correct behaviour and is left alone.
* **33** where the **documentation** describes an optional parameter no lowering implements (`(string-pad-left s width [char])` vs `THREE_ARG_BUILTIN(stringPadLeft…)`, which answers null for the two-argument call). Per the project rule that the documentation is the specification, these are **recorded as build items, not edited down**; `scripts/gen_builtin_min_arity.py` prints all 33 by name and page.

## The fix

**One derived fact.** `scripts/gen_builtin_min_arity.py` derives every row's caller minimum, in descending order of authority — every source is *code that runs*, except the last:

1. **the fixed-arity macro the native dispatch expands** — `<N>_ARG_BUILTIN` / `CE_<N>_ARG` expand to `if (num_vars != N) return packNull();`;
2. **a lowering with an explicit zero-argument case** — `bytevector-append`'s block opens `if (n == 0) { …empty bytevector…; co_return … }`, so `(bytevector-append)` is the identity. A zero-case that *errors*, warns or answers null is not read as one;
3. **the arity guard the lowering enforces**, which names the optional parameter: `substring requires 2 or 3 arguments: (substring string start [end])`;
4. **the Scheme definition native compiles** — `append` has no lowering at all; `lib/core/list/transform.esk` defines `(define (append . lists) (cond ((null? lists) '()) …))`, a rest-argument lambda with zero required parameters whose first clause *is* the R7RS 6.4 identity;
5. **a declarative documented signature** — `(read-line [port]) — …`, never an example call, because `(make-vector 3)` appears in a hundred documents as something a program *does*.

`min_arity` gains an explicit marker for a documented minimum of genuinely **zero**, which `0 == unset` had made unsayable — which is why `(read-line)` and `(append)` were refused at all.

**Refusing was only half of it, and a variadic row was the worse half.** `hash-ref` already had its column filled in and still failed — at *runtime*, where the builtin body loads three operands and `vm_validate_closure_arity` wants exactly three. A row declared **variadic** (`gcd`, `lcm`) is worse still: it makes no minimum claim, so the compile-time check never fires for it, and `(gcd)` compiled clean and died at the closure call. So the call site now **supplies** the operands the caller omitted, as `ESHKOL_ABSENT_ARG` (the VM's unspecified value, which no source expression evaluates to), and the native op reads that marker and applies the documented default or identity: `substring`'s missing `end` is the string's length, `make-vector`'s missing fill is `0`, `read-line`'s missing port is the current input, `(append)` is `()`, `(gcd)` is 0, `(lcm)` is 1, `(bytevector-append)` is the empty bytevector. Lowering a row's minimum without teaching its op the default would turn a refused call into a wrong answer, so the two land together.

Three readers also answered `()` at end of input where native answers the eof object — `tests/io/binary_io_test.esk` was already written against the eof object.

**One wording, still.** Native's `substring` guard renders the canonical sentence for the under-arity direction, so both engines print `Arity mismatch: substring expects 2 arguments but got 1` — the **minimum**, not the opcode's three operands. The over-arity direction keeps its more specific sentence and the marker `eshkol_arity_error_current()` prepends.

**Drift fails the build.** `scripts/check_builtin_min_arity.py` imports the generator and **re-derives** — it does not re-read the column it is checking — so editing a guard, a macro, a core-module definition or a signature without regenerating the table is a build failure rather than a new divergence. The caller minimum also reaches `tests/coverage/language_surface.json`, which every exposure harness reads.

## Tests

* `tests/vm_parity/corpus/82_builtin_optional_argument_arity.esk` — all nineteen at minimum **and** maximum arity, including `(append)`, `(gcd)`, `(lcm)` and `(bytevector-append)`; byte-identical transcripts on both engines. The four readers whose minimum call takes no port appear as definitions that are never applied: their contract here is *acceptance*, which compiling the file proves, and applying one would read the harness's stdin.
* `tests/diagnostics/arity_below_documented_minimum` — an under-minimum call pinned to the canonical sentence, quoting the minimum, with its span.

## Verification (rebased onto the candidate)

| gate | result |
|---|---|
| probe, 19 builtins × min and max arity | **0 acceptance divergences**, 34 calls checked |
| `python3 scripts/check_builtin_min_arity.py` | PASS — 739 rows agree with their macro / zero-case / guard / definition / signature |
| `python3 scripts/gen_language_surface.py --check` | OK |
| `scripts/run_vm_parity.sh` | 298 passed, 0 failed |
| `BUILD_DIR=build bash scripts/run_p8_escape.sh --quick` | **gate PASS** — axis 3 no NEW divergence, axis 6 now PASS too |
| `scripts/check_diagnostic_corpus.py` | 17/17 |
| `ctest -R "arity\|vm_parity\|p8\|diagnostic\|string\|vector"` | 22/22 |
| `python3 scripts/check_wasm_imports.py` | OK |
| `scripts/regenerate_vm_prelude_cache.sh --check` / `check_vm_prelude_cache_builtins.py` | PASS |
| `./scripts/run_all_tests.sh` | 100%, exit 0 |

Four **value** divergences the probe uncovered are filed in `docs/KNOWN_ISSUES.md` as their own build items; each reproduces at full arity and none is about arity: `(hash-ref t k default)` answers the default's raw integer bits on the VM, `(write-string s)` answers `0` on native and the unspecified value on the VM, `(make-tensor shape)` builds a rank-1 tensor on native, and the `(bytevector …)` constructor and `current-input-port` / `current-output-port` are not callable on the VM at all.
